### PR TITLE
Bump buildworker container to v9

### DIFF
--- a/.github/dockerfiles/Dockerfile.tools
+++ b/.github/dockerfiles/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v6
+FROM ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v9
 
 COPY --chown=buildbot staging_dir/host /prebuilt_tools/staging_dir/host
 COPY --chown=buildbot build_dir/host /prebuilt_tools/build_dir/host

--- a/.github/workflows/reusable_build-tools.yml
+++ b/.github/workflows/reusable_build-tools.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build tools
     runs-on: ubuntu-latest
-    container: ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v6
+    container: ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v9
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### TODO

- [x] bump all buildbot workers to same v9 image 

### Description

Contains following changes since the v6:

 * docker,worker: install pyelftools
 * phase1: workaround dlprune recursive directory removal
 * phase1: prepareFactory: use variables instead of list index
 * phase1: populateTargets: log branch name as well
 * phase1: do not leak targets between branches
 * phase1: reformat with black
 * phase1: dlprune: fix cannot delete ‘dl/’: Not a directory

Where the relevant one is pyelftools commit which is needed for recent U-Boot 2023.07.02 release.

References: https://github.com/openwrt/openwrt/pull/12974
References: https://github.com/openwrt/openwrt/commit/12da976c38bf2ea65edb71ea69cd7166934db776