### PR TITLE
reusable_build: assure source code tarball integrity

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -437,6 +437,22 @@ jobs:
         working-directory: openwrt
         run: ./scripts/diffconfig.sh
 
+      - name: Download sources
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: make -j $(nproc) download check FIXUP=1
+
+      - name: Check sources integrity
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          git diff-index --exit-code HEAD || {
+            ret=$?
+            echo "Package integrity issues, please check the output bellow or packages-hash-issues.patch from artifacts"
+            git diff | tee packages-hash-issues.patch
+            exit $ret
+          }
+
       - name: Build tools
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt


### PR DESCRIPTION
Increase QA coverage of source code tarball handling by downloading the source code tarballs and checking their integrity against `PKG_MIRROR_HASH`.

References: [4a57e786a1e0](https://github.com/openwrt/openwrt/commit/4a57e786a1e0ed4e3d600370b0bc86db33daf3cc) ("urngd: fix archived tar hash")