### PR TITLE
CI: Run package/check on all packages

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -62,6 +62,9 @@ on:
         default: kernel
       upload_ccache_cache:
         type: boolean
+      check:
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -134,9 +137,84 @@ jobs:
           echo "container_tag=$CONTAINER_TAG" >> $GITHUB_OUTPUT
           echo "container_name=$CONTAINER_NAME" >> $GITHUB_OUTPUT
 
+  check:
+    name: Check packages for ${{ inputs.target }}/${{ inputs.subtarget }}
+    needs: setup_build
+    if: inputs.check == true
+    runs-on: ubuntu-latest
+
+    container: ghcr.io/${{ needs.setup_build.outputs.owner_lc }}/${{ needs.setup_build.outputs.container_name }}:${{ needs.setup_build.outputs.container_tag }}
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout master directory
+        uses: actions/checkout@v3
+        with:
+          path: openwrt
+
+      - name: Fix permission
+        run: |
+          chown -R buildbot:buildbot openwrt
+
+      - name: Configure all modules
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          echo CONFIG_ALL=y >> .config
+
+          echo CONFIG_TARGET_MULTI_PROFILE=y >> .config
+          echo CONFIG_TARGET_PER_DEVICE_ROOTFS=y >> .config
+          echo CONFIG_TARGET_ALL_PROFILES=y >> .config
+
+          echo CONFIG_DEVEL=y >> .config
+          echo CONFIG_AUTOREMOVE=y >> .config
+
+          echo "CONFIG_TARGET_${{ inputs.target }}=y" >> .config
+          echo "CONFIG_TARGET_${{ inputs.target }}_${{ inputs.subtarget }}=y" >> .config
+
+          make defconfig
+
+      - name: Compile needed host tools
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: make tools/tar/compile -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
+
+      - name: Download and check packages
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: make download check FIXUP=1 -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
+
+      - name: Validate checked packages
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          . .github/workflows/scripts/ci_helpers.sh
+
+          if git diff --name-only --exit-code; then
+            success "All packages seems ok"
+          else
+            err "Some package Makefiles requires fix. (run 'make package/check FIXUP=1' and force push this pr)"
+            err "You can also check the provided artifacts with the refreshed patch from this CI run."
+            mkdir packages-fixed
+            for f in $(git diff --name-only); do
+              cp --parents $f packages-fixed/
+            done
+            exit 1
+          fi
+
+      - name: Upload fixed Packages
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages-fixed
+          path: openwrt/packages-fixed
+
   build:
     name: Build ${{ inputs.target }}/${{ inputs.subtarget }}
-    needs: setup_build
+    needs: check
     runs-on: ubuntu-latest
 
     container: ghcr.io/${{ needs.setup_build.outputs.owner_lc }}/${{ needs.setup_build.outputs.container_name }}:${{ needs.setup_build.outputs.container_tag }}
@@ -147,11 +225,6 @@ jobs:
       actions: write
 
     steps:
-      - name: Checkout master directory
-        uses: actions/checkout@v3
-        with:
-          path: openwrt
-
       - name: Checkout packages feed
         if: inputs.include_feeds == true
         uses: actions/checkout@v3
@@ -296,6 +369,12 @@ jobs:
           sha256sum --check --ignore-missing sha256sums
           tar --xz -xf ${{ env.TOOLCHAIN_FILE }}.tar.xz
           rm ${{ env.TOOLCHAIN_FILE }}.tar.xz sha256sums
+
+      - name: Clean configuration
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          rm -rf .config
 
       - name: Configure testing kernel
         if: inputs.testing == true


### PR DESCRIPTION
This will check some basic properties on all package Makefiles after the full build. It checks for example if the PKG_HASH is correct and will fail if it is not correct. This should detect such problems before they get merged.

This will always be executed when we do a full package build, the check is pretty fast.

Previously located here: https://github.com/openwrt/openwrt/pull/12803