### PR TITLE
CI: Increase context in case of build error

### DIFF
--- a/.github/workflows/scripts/show_build_failures.sh
+++ b/.github/workflows/scripts/show_build_failures.sh
@@ -2,7 +2,7 @@
 
 original_exit_code="${ret:-1}"
 log_dir_path="${1:-logs}"
-context="${2:-10}"
+context="${2:-20}"
 
 show_make_build_errors() {
 	grep -slr 'make\[[[:digit:]]\+\].*Error [[:digit:]]\+$' "$log_dir_path" | while IFS= read -r log_file; do


### PR DESCRIPTION
This shows more lines of context in case the build runs into a problem. Sometimes the real error was not shown in the output, only some follow up problems. I hope it will be better when we show 20 lines instead of 10 lines around the error message.