### PR TITLE
Try to prevent harder buildbot failures

### DIFF
--- a/.github/workflows/label-target.yml
+++ b/.github/workflows/label-target.yml
@@ -35,6 +35,8 @@ jobs:
       target: ${{ needs.set_target.outputs.target }}
       subtarget: ${{ needs.set_target.outputs.subtarget }}
       build_full: true
+      build_ib_sdk: true
+      build_bpf_toolchain: true
       build_all_kmods: true
       build_all_boards: true
       build_all_modules: true

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -77,6 +77,8 @@ jobs:
       build_all_kmods: true
       build_all_modules: true
       build_full: true
+      build_ib_sdk: true
+      build_bpf_toolchain: true
       ccache_type: packages
       upload_ccache_cache: ${{ github.repository_owner == 'openwrt' }}
       check_packages_list: ${{ needs.determine_changed_packages.outputs.changed_packages }}

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -33,6 +33,10 @@ on:
         type: boolean
       build_all_boards:
         type: boolean
+      build_ib_sdk:
+        type: boolean
+      build_bpf_toolchain:
+        type: boolean
       use_openwrt_container:
         type: boolean
         default: true
@@ -446,6 +450,33 @@ jobs:
         working-directory: openwrt
         run: |
           echo CONFIG_KERNEL_WERROR=y >> .config
+
+      - name: Configure various options which are used on buildbots
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          echo CONFIG_JSON_CYCLONEDX_SBOM=y >> .config
+          echo CONFIG_COLLECT_KERNEL_DEBUG=y >> .config
+          echo CONFIG_REPRODUCIBLE_DEBUG_INFO=y >> .config
+          echo CONFIG_KERNEL_BUILD_USER="builder" >> .config
+          echo CONFIG_KERNEL_BUILD_DOMAIN="buildhost" >> .config
+
+      - name: Configure BPF options as used on buildbots
+        shell: su buildbot -c "sh -e {0}"
+        if: inputs.build_bpf_toolchain == true
+        working-directory: openwrt
+        run: |
+          echo CONFIG_DEVEL=y >> .config
+          echo CONFIG_SDK_LLVM_BPF=y >> .config
+          echo CONFIG_BPF_TOOLCHAIN_BUILD_LLVM=y >> .config
+
+      - name: Configure SDK and IB options used on buildbots
+        shell: su buildbot -c "sh -e {0}"
+        if: inputs.build_ib_sdk == true
+        working-directory: openwrt
+        run: |
+          echo CONFIG_IB=y >> .config
+          echo CONFIG_SDK=y >> .config
 
       - name: Configure all kernel modules
         if: inputs.build_all_kmods == true

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -53,3 +53,4 @@ jobs:
       target: ${{ matrix.target }}
       subtarget: ${{ matrix.subtarget }}
       build_toolchain: true
+      build_bpf_toolchain: true


### PR DESCRIPTION
Merging pull request #14218 (with all 190 CI checks green) resulted in buildbot failures in `Kernel/CollectDebug` step, likely due to the fact, that CI builds don't use same config options as on buildbot, specifically CI builds currently don't have `COLLECT_KERNEL_DEBUG` config option enabled.

So lets try to prevent those regressions in the future by aligning the CI build process with the build config options used later on the buildbots.

References: 066b0fee7668 ("kernel: copy only *.ko for debug info")
References: https://github.com/openwrt/openwrt/pull/14218