### PR TITLE
tools: enable SDK option to build more tools

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Make prereq
         working-directory: ${{ env.WORKPATH }}/openwrt
-        run: make defconfig
+        run: |
+          echo CONFIG_SDK=y >> .config
+          make defconfig
 
       - name: Build tools MacOS
         working-directory: ${{ env.WORKPATH }}/openwrt


### PR DESCRIPTION
Without the SDK option multiple tools are skipped, i.e. bzip2.