### PR TITLE
CI: switch to macOS 14 (Sonoma) 

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -42,7 +42,6 @@ jobs:
             echo "/usr/local/bin" >> "$GITHUB_PATH"
             echo "/usr/local/opt/coreutils/bin" >> "$GITHUB_PATH"
             echo "/usr/local/opt/findutils/libexec/gnubin" >> "$GITHUB_PATH"
-            echo "/usr/local/opt/gettext/bin" >> "$GITHUB_PATH"
             echo "/usr/local/opt/gnu-getopt/bin" >> "$GITHUB_PATH"
             echo "/usr/local/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
             echo "/usr/sbin" >> "$GITHUB_PATH"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -34,6 +34,7 @@ jobs:
             gnu-getopt \
             gnu-sed \
             grep \
+            gpatch \
             make
 
             echo "/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-macos-latest:
     name: Build tools with macos latest
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout
@@ -40,11 +40,11 @@ jobs:
             echo "/bin" >> "$GITHUB_PATH"
             echo "/sbin/Library/Apple/usr/bin" >> "$GITHUB_PATH"
             echo "/usr/bin" >> "$GITHUB_PATH"
-            echo "/usr/local/bin" >> "$GITHUB_PATH"
-            echo "/usr/local/opt/coreutils/bin" >> "$GITHUB_PATH"
-            echo "/usr/local/opt/findutils/libexec/gnubin" >> "$GITHUB_PATH"
-            echo "/usr/local/opt/gnu-getopt/bin" >> "$GITHUB_PATH"
-            echo "/usr/local/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
+            echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+            echo "/opt/homebrew/opt/coreutils/bin" >> "$GITHUB_PATH"
+            echo "/opt/homebrew/opt/findutils/libexec/gnubin" >> "$GITHUB_PATH"
+            echo "/opt/homebrew/opt/gnu-getopt/bin" >> "$GITHUB_PATH"
+            echo "/opt/homebrew/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
             echo "/usr/sbin" >> "$GITHUB_PATH"
 
       - name: Make prereq

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -45,7 +45,6 @@ jobs:
             echo "/usr/local/opt/gettext/bin" >> "$GITHUB_PATH"
             echo "/usr/local/opt/gnu-getopt/bin" >> "$GITHUB_PATH"
             echo "/usr/local/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
-            echo "/usr/local/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
             echo "/usr/sbin" >> "$GITHUB_PATH"
 
       - name: Make prereq


### PR DESCRIPTION
This switches the build to MacOS 14.

I did a test run here:
https://github.com/hauke/openwrt/actions/runs/8318176338/job/22759803760

 * CI: macos: Remove double gnubin path
    
    This path was added twice.

 * CI: macos: Do not add gettext to path
    
    gettext is never installed.

 * CI: macos: Install gpatch too
    
    This was probably already installed in the macos12 image, but it is
    missing in macos14.

 * CI: macos: Use macOS 14 (Sonoma)
    
    This will be the default in some months, use it already now:
    https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
    
    brew installs the applications into new paths now.