### PR TITLE
kernel: fix change detection for kernel builds

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -70,9 +70,8 @@ jobs:
             TARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 1)
             SUBTARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 2)
 
-            if echo "$CHANGED_FILES" | grep -v -q -P ^target/linux/.*/ ||
-              echo "$CHANGED_FILES" | grep -q target/linux/generic ||
-              echo "$CHANGED_FILES" | grep -q $TARGET; then
+            if echo "$CHANGED_FILES" | grep -q target/linux/generic ||
+              echo "$CHANGED_FILES" | grep -q "target/linux/$TARGET"; then
 
               # test target if kernel version is affected
               # If AFFECTED_KERNEL_VERSIONS is empty fallback to simple testing (case of changed files)
@@ -103,9 +102,8 @@ jobs:
             TARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 1)
             SUBTARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 2)
 
-            if echo "$CHANGED_FILES" | grep -v -q -P ^target/linux/.*/ ||
-              echo "$CHANGED_FILES" | grep -q target/linux/generic ||
-              echo "$CHANGED_FILES" | grep -q $TARGET; then
+            if echo "$CHANGED_FILES" | grep -q target/linux/generic ||
+              echo "$CHANGED_FILES" | grep -q "target/linux/$TARGET"; then
 
               # test target if kernel version is affected
               # If AFFECTED_KERNEL_VERSIONS is empty fallback to simple testing (case of changed files)


### PR DESCRIPTION
Targets were previously added for testing if one of the following three conditionn is true regarding the changed files:

- changes contain anything but `target/linux/.*/`
- changes in `target/linux/generic`
- changes contain `$TARGET`

The first condition is true for nearly any change, causing Kernels being tested all the time. The new logic changes the conditions to one of the following two:

- changes in `target/linux/generic`
- changes `target/linux/$TARGET`

In a quick test, this reduced tested kernel from $ALL to literally just the one which was changed.