### PR TITLE
kernel: correctly fix kernel package detection

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -71,7 +71,8 @@ jobs:
             SUBTARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 2)
 
             if echo "$CHANGED_FILES" | grep -q target/linux/generic ||
-              echo "$CHANGED_FILES" | grep -q "$TARGET"; then
+              echo "$CHANGED_FILES" | grep -q "package/kernel" ||
+              echo "$CHANGED_FILES" | grep -q "target/linux/$TARGET"; then
 
               # test target if kernel version is affected
               # If AFFECTED_KERNEL_VERSIONS is empty fallback to simple testing (case of changed files)
@@ -103,7 +104,8 @@ jobs:
             SUBTARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 2)
 
             if echo "$CHANGED_FILES" | grep -q target/linux/generic ||
-              echo "$CHANGED_FILES" | grep -q "$TARGET"; then
+              echo "$CHANGED_FILES" | grep -q "package/kernel" ||
+              echo "$CHANGED_FILES" | grep -q "target/linux/$TARGET"; then
 
               # test target if kernel version is affected
               # If AFFECTED_KERNEL_VERSIONS is empty fallback to simple testing (case of changed files)


### PR DESCRIPTION
Previous fix would only work for lantiq since it has a somewhat special place in the folder. Now any change of kernel packages triggers a kernel test. This adds extra computation but should detect many more errors.