### PR TITLE
CI: tools: switch to use the latest macOS for x64

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -5,8 +5,8 @@ on:
 
 jobs:
   build-macos-latest:
-    name: Build tools with macos latest
-    runs-on: macos-latest
+    name: Build tools with macOS x64 latest
+    runs-on: macos-latest-large
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Recently, macOS runner on GitHub was migrated from macOS 12 (Monterey) to macOS (14), but with this switch macos-latest is now pointing to arm64 build, which is currently failing while building OpenWrt.

E.g. error log:
```
Checking 'working-make'... failed.
Details: https://github.com/openwrt/openwrt/actions/runs/8834725561/job/24257119788?pr=15269
```
Previously with the macOS 12, we were using x64 builds, so stick for it, for now.

[1] https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image

_____

Available images can be found here:
https://github.com/actions/runner-images?tab=readme-ov-file#available-images