### PR TITLE
reusable_build: provide info about disk usage before and after build

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -285,6 +285,12 @@ jobs:
         with:
           path: openwrt
 
+      - name: Provide information about disk usage before the build
+        if: always()
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: df -h . ; du -sh .
+
       - name: Checkout packages feed
         if: inputs.include_feeds == true
         uses: actions/checkout@v4
@@ -683,6 +689,12 @@ jobs:
         with:
           name: ${{ inputs.target }}-${{ inputs.subtarget }}${{ inputs.testing == true && '-testing' || '' }}-logs
           path: "openwrt/logs"
+
+      - name: Provide information about disk usage after the build
+        if: always()
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: df -h . ; du -sh .
 
       - name: Cleanup dl/build_dir/staging_dir to make some space
         working-directory: openwrt


### PR DESCRIPTION
Currently we've CI workflows failing due to:

```shell
 cp: error writing '/__w/openwrt/openwrt/openwrt/build_dir/target-aarch64-openwrt-linux-musl_musl/linux-mediatek_filogic/linux-6.6.60.141efc9e/net/netfilter/ipvs/ip_vs_wrr.ko': No space left on device
 cp: error writing '/__w/openwrt/openwrt/openwrt/build_dir/target-aarch64-openwrt-linux-musl_musl/linux-mediatek_filogic/linux-6.6.60.41081c68/tools/perf/pmu-events/arch/s390/cf_z196/crypto.json': No space left on device
 cp: error writing '/__w/openwrt/openwrt/openwrt/build_dir/target-aarch64-openwrt-linux-musl_musl/linux-mediatek_filogic/linux-6.6.60.141efc9e/net/netfilter/ipvs/.ip_vs.ko.cmd': No space left on device
 cp: error writing '/__w/openwrt/openwrt/openwrt/build_dir/target-aarch64-openwrt-linux-musl_musl/linux-mediatek_filogic/linux-6.6.60.141efc9e/net/netfilter/ipvs/.ip_vs_lc.ko.
```

So in such cases, lets make the post mortem debugging a bit easier and provide information about runner disk space before and after the build.