### PR TITLE
build: test container: don't pull from docker hub; half support apk files

### DIFF
--- a/.github/dockerfiles_feeds/entrypoint.sh
+++ b/.github/dockerfiles_feeds/entrypoint.sh
@@ -4,6 +4,12 @@
 set -o errexit # failing commands causes script to fail
 set -o nounset # undefined variables causes script to fail
 
+if [ -z "$(find . -maxdepth 1 -type f -name '*.ipk' -print)" ]
+then
+	echo "this script can only test ipk packages, and none were found"
+	exit 0
+fi
+
 echo "src/gz packages_ci file:///ci" >> /etc/opkg/distfeeds.conf
 
 FINGERPRINT="$(usign -F -p /ci/packages_ci.pub)"

--- a/.github/scripts/get-rootfs-url.py
+++ b/.github/scripts/get-rootfs-url.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import logging
+import os
+import requests
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+"""
+our inputs:
+ BRANCH=master or openwrt-23.05 or openwrt-24.10 etc.
+   for 23.05, we want something from https://downloads.openwrt.org/releases/23.05-SNAPSHOT/targets/
+   for master, https://downloads.openwrt.org/snapshots/targets/
+ TARGET=x86_64 or similar
+   which means x86/64 (so _ becomes /) inside our targets/ dir
+"""
+
+# TODO: once this goes at the end of the yml, exit 1 on failure
+
+def main():
+    branch = os.environ["BRANCH"]
+    target = os.environ["TARGET"]
+
+    target = target.replace('-', '/')
+
+    log.debug(f"got branch {branch}, path for target {target}")
+
+    if branch == 'master':
+        baseurl = 'https://downloads.openwrt.org/snapshots/targets/'
+    elif branch.startswith('openwrt-'):
+        rel = branch[8:]
+        baseurl = 'https://downloads.openwrt.org/releases/' + rel + '-SNAPSHOT/targets/'
+    else:
+        raise Exception("don't know downloads URL for branch " + branch)
+
+    targeturl = baseurl + target
+
+    # log.debug(f"getting ")
+    sha256sumsreq = requests.get(targeturl + '/sha256sums')
+
+    if sha256sumsreq.status_code != 200:
+        log.error("got non-200 code, stopping")
+        return
+
+    sha256sums = sha256sumsreq.text
+
+    # print(sha256sums)
+    for line in sha256sums.splitlines():
+        hash, fname = line.split()
+        if fname.endswith('rootfs.tar.gz'):
+            if fname.startswith('*'):
+                fname = fname[1:]
+            print(targeturl + '/' + fname)
+            return
+
+    log.error("did not find a rootfs.tar.gz in sha256sums, stopping")
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -182,36 +182,50 @@ jobs:
 
       - name: Check if any packages were built
         run: |
-          if [ -n "$(find . -maxdepth 1 -type f -name '*.ipk' -print -quit)" ]; then
-            echo "Found *.ipk files"
-            HAVE_IPKS=true
+          if [ -n "$(find . -maxdepth 1 -type f -name '*.[ai]pk' -print -quit)" ]; then
+            echo "Found *.ipk or *.apk files"
+            HAVE_PKGS=true
           else
-            echo "No *.ipk files found"
-            HAVE_IPKS=false
+            echo "No *.ipk or *.apk files found"
+            HAVE_PKGS=false
           fi
-          echo "HAVE_IPKS=$HAVE_IPKS" >> $GITHUB_ENV
+          echo "HAVE_PKGS=$HAVE_PKGS" >> $GITHUB_ENV
 
       - name: Register QEMU
-        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
+        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_PKGS) }}
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static binfmt-support
           sudo update-binfmts --import
 
       - name: Checkout
-        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
+        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_PKGS) }}
         uses: actions/checkout@v4
         with:
           repository: openwrt/actions-shared-workflows
           path: dockerfiles_feeds
           sparse-checkout: |
             .github/scripts/ci_helpers.sh
+            .github/scripts/get-rootfs-url.py
             .github/dockerfiles_feeds/Dockerfile
             .github/dockerfiles_feeds/entrypoint.sh
           sparse-checkout-cone-mode: false
 
+      - name: Get rootfs
+        if: ${{ matrix.runtime_test }}
+        run: |
+          ROOTFSFILE=$(dockerfiles_feeds/.github/scripts/get-rootfs-url.py)
+          echo $ROOTFSFILE
+          if [ -z "$ROOTFSFILE" ] ; then echo "no rootfs" ; exit 1 ; fi
+          docker import $ROOTFSFILE openwrt/rootfs:$ARCH
+          docker images
+        env:
+          ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
+          BRANCH: ${{ env.BRANCH }}
+          TARGET: ${{ matrix.target }}
+
       - name: Build Docker container
-        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
+        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_PKGS) }}
         run: |
           docker build --platform linux/${{ matrix.arch }} -t test-container \
             --build-arg ARCH dockerfiles_feeds/.github/dockerfiles_feeds/
@@ -219,7 +233,7 @@ jobs:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
 
       - name: Test via Docker container
-        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_IPKS) }}
+        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_PKGS) }}
         run: |
           docker run --platform linux/${{ matrix.arch }} --rm -v $GITHUB_WORKSPACE:/ci \
             -v $GITHUB_WORKSPACE/dockerfiles_feeds:/dockerfiles_feeds \


### PR DESCRIPTION
as requested by @aparcar, this fetches rootfs files from downloads, instead of relying on what's on docker hub.

TODO before merge:
* [ ] disable, or fix, `mips_24kc`

TODO later (hopefully somebody else can pick this up after this is merged): 
* test .apk files in `entrypoint.sh`

[master test run](https://github.com/Habbie/openwrt-packages/actions/runs/11861321083/job/33086876013)

[24.10 test run](https://github.com/Habbie/openwrt-packages/actions/runs/11872859479/job/33087063153)
