### PR TITLE
tools: macos: include python-setuptools and swig

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -35,7 +35,9 @@ jobs:
             gnu-sed \
             grep \
             gpatch \
-            make
+            make \
+            python-setuptools \
+            swig
 
             echo "/bin" >> "$GITHUB_PATH"
             echo "/sbin/Library/Apple/usr/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
Now that OpenWrt One is the default target, we need to include Python setuptools and swig since mediatek target U-Boot build requires it.