### PR TITLE
Bump buildworker container to one used by buildbots

### DIFF
--- a/.github/dockerfiles/Dockerfile.tools
+++ b/.github/dockerfiles/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v9
+FROM ghcr.io/openwrt/buildbot/buildworker-v3.11.8:v22
 
 COPY --chown=buildbot staging_dir/host /prebuilt_tools/staging_dir/host
 COPY --chown=buildbot build_dir/host /prebuilt_tools/build_dir/host

--- a/.github/workflows/reusable_build-tools.yml
+++ b/.github/workflows/reusable_build-tools.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build tools
     runs-on: ubuntu-latest
-    container: ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v9
+    container: ghcr.io/openwrt/buildbot/buildworker-v3.11.8:v22
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Update the buildworker container to the current 3.11.8 v22 that is used by buildbots.