### PR TITLE
Bump buildworker container to v23

### DIFF
--- a/.github/dockerfiles/Dockerfile.tools
+++ b/.github/dockerfiles/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM ghcr.io/openwrt/buildbot/buildworker-v3.11.8:v22
+FROM ghcr.io/openwrt/buildbot/buildworker-v3.11.8:v23
 
 COPY --chown=buildbot staging_dir/host /prebuilt_tools/staging_dir/host
 COPY --chown=buildbot build_dir/host /prebuilt_tools/build_dir/host

--- a/.github/workflows/reusable_build-tools.yml
+++ b/.github/workflows/reusable_build-tools.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build tools
     runs-on: ubuntu-latest
-    container: ghcr.io/openwrt/buildbot/buildworker-v3.11.8:v22
+    container: ghcr.io/openwrt/buildbot/buildworker-v3.11.8:v23
 
     steps:
       - name: Checkout


### PR DESCRIPTION
STM32 needs python3-cryptography which is only present in v23 containers.

Buildbots are actually running v23 because of this and I misread the hash.

Fixes: 824d6eb253b8 ("Bump buildworker container to one used by buildbots")