### PR TITLE
tools: macos: use MacOS 15 and latest XCode

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -14,6 +14,11 @@ jobs:
         with:
           path: openwrt
 
+      - name: Set XCode to latest
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - name: Setup MacOS
         run: |
           echo "WORKPATH=/Volumes/OpenWrt" >> "$GITHUB_ENV"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-macos-latest:
     name: Build tools with macos latest
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Currently, we are relying on the macos-latest tag, which is currently MacOS 14, which unfortunately does not allow using the latest XCode.

So, instead of waiting for users to report tools failing to compile with the current MacOS 15 and XCode 16.3 and so on, we can just move to using the macos-15 images and then always use the latest stable XCode.