### PR TITLE
multi-arch-test-build: add APK package signing

### DIFF
--- a/.github/dockerfiles_feeds/entrypoint.sh
+++ b/.github/dockerfiles_feeds/entrypoint.sh
@@ -14,6 +14,8 @@ if [ $PKG_MANAGER = "opkg" ]; then
 	cp /ci/packages_ci.pub "/etc/opkg/keys/$FINGERPRINT"
 
 	opkg update
+elif [ $PKG_MANAGER = "apk" ]; then
+	cp /ci/packages-ci-public.pem "/etc/apk/keys/"
 fi
 
 CI_HELPER="${CI_HELPER:-/ci/.github/workflows/ci_helpers.sh}"
@@ -73,7 +75,7 @@ for PKG in /ci/*.[ai]pk; do
 	if [ $PKG_MANAGER = "opkg" ]; then
 		opkg install "$PKG"
 	elif [ $PKG_MANAGER = "apk" ]; then
-		apk add --allow-untrusted "$PKG"
+		apk add "$PKG"
 	fi
 
 	echo "Use package specific test.sh"

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -95,7 +95,7 @@ jobs:
           echo "Building $PACKAGES"
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
-      - name: Generate build keys
+      - name: Generate OPKG build keys
         run: |
           sudo apt-get update
           sudo apt-get install -y signify-openbsd
@@ -105,13 +105,23 @@ jobs:
           cat packages_ci.sec >> $GITHUB_ENV
           echo "$EOF" >> $GITHUB_ENV
 
+      - name: Generate APK build keys
+        run: |
+          openssl ecparam -name prime256v1 -genkey -noout -out packages-ci-private.pem
+          openssl ec -in packages-ci-private.pem -pubout > packages-ci-public.pem
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "PRIVATE_KEY<<$EOF" >> $GITHUB_ENV
+          cat packages-ci-private.pem >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
+
       - name: Build
-        uses: openwrt/gh-action-sdk@v7
+        uses: openwrt/gh-action-sdk@v8
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: packages_ci
           INDEX: 1
           KEY_BUILD: ${{ env.KEY_BUILD }}
+          PRIVATE_KEY: ${{ env.PRIVATE_KEY }}
           V: s
 
       - name: Move created packages to project dir


### PR DESCRIPTION
Now that gh-action-sdk supports APK package signing, lets support it during CI builds.