### PR TITLE
CI: dockerfiles_feeds: add local APK feed

### DIFF
--- a/.github/dockerfiles_feeds/entrypoint.sh
+++ b/.github/dockerfiles_feeds/entrypoint.sh
@@ -15,7 +15,11 @@ if [ $PKG_MANAGER = "opkg" ]; then
 
 	opkg update
 elif [ $PKG_MANAGER = "apk" ]; then
+	echo "/ci/packages.adb" >> /etc/apk/repositories.d/distfeeds.list
+
 	cp /ci/packages-ci-public.pem "/etc/apk/keys/"
+
+	apk update
 fi
 
 CI_HELPER="${CI_HELPER:-/ci/.github/workflows/ci_helpers.sh}"


### PR DESCRIPTION
Currently APK package dependencies are installed from the standard feeds. This may lead to test errors due to dependency mismatch/missing dependencies.

This adds a local APK package feed so that dependencies are installed from locally built packages.

Fixes: https://github.com/openwrt/actions-shared-workflows/issues/41