### PR TITLE
CI: multi-arch-test-build: add telephony feed

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -88,6 +88,8 @@ jobs:
           REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}
           if [ "$REPOSITORY_NAME" = "routing" ]; then
             PACKAGES="${PACKAGES:-bird2 cjdns olsrd}"
+          elif [ "$REPOSITORY_NAME" = "telephony" ]; then
+	    PACKAGES="${PACKAGES:-asterisk siproxd freeswitch}"
           else
             PACKAGES="${PACKAGES:-vim attendedsysupgrade-common bmon}"
           fi


### PR DESCRIPTION
Add default packages for the telephony repository, because right now, it only counts with packages repository and routing repository.