### PR TITLE
multi-arch-test-build: Workaround riscv64_riscv64 rename

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -47,7 +47,8 @@ jobs:
             target: mpc85xx-p1010
             runtime_test: false
 
-          - arch: riscv64_generic
+            # Workaround: riscv64_riscv64 was renamed to riscv64_generic
+          - arch: ${{ (github.base_ref == 'openwrt-24.10' || github.base_ref == 'openwrt-23.05') && 'riscv64_riscv64' || 'riscv64_generic' }}
             target: sifiveu-generic
             runtime_test: false
 


### PR DESCRIPTION
Since commit 661a51bec860974483a7ba213bb4bba9a9426481 PRs for `openwrt/packages` 24.10 / 23.05 have been "failing" because riscv64_generic doesn't exist.

This PR works around this by targeting `riscv64_riscv64` when the base_ref is 24.10 or 23.05 (should be future-release compatible written this way).