### PR TITLE
CI: Run formal tests on PR-s

### DIFF
--- a/.github/workflows/formal-this-repo.yaml
+++ b/.github/workflows/formal-this-repo.yaml
@@ -1,0 +1,12 @@
+name: Test Formalities
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Test Formalities
+    uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@main


### PR DESCRIPTION
This repo follows the same rules as other OpenWrt repos, so lets run the formal workflow on this repo as well.