### PR TITLE
CI: Import gpg keys from repository

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -432,11 +432,24 @@ jobs:
           restore-keys: |
             ${{ needs.setup_build.outputs.ccache_name }}-
 
+      - name: Checkout OpenWrt keyring
+        if: inputs.build_toolchain == false && ((steps.parse-toolchain.outputs.toolchain-type != 'internal' && steps.parse-toolchain.outputs.toolchain-type != 'external_container') ||
+          steps.parse-prebuilt-llvm.outputs.llvm-type == 'external')
+        uses: actions/checkout@v4
+        with:
+          repository: openwrt/keyring
+          path: keyring
+          sparse-checkout: |
+            gpg/CD54E82DADB3684D.asc
+            gpg/0x1D53D1877742E911.asc
+            gpg/626471F1.asc
+          sparse-checkout-cone-mode: false
+
       - name: Import GPG keys
         shell: su buildbot -c "sh -e {0}"
         if: inputs.build_toolchain == false && ((steps.parse-toolchain.outputs.toolchain-type != 'internal' && steps.parse-toolchain.outputs.toolchain-type != 'external_container') ||
           steps.parse-prebuilt-llvm.outputs.llvm-type == 'external')
-        run: gpg --receive-keys 0xCD84BCED626471F1 0x1D53D1877742E911 0xCD54E82DADB3684D
+        run: gpg --import keyring/gpg/CD54E82DADB3684D.asc keyring/gpg/0x1D53D1877742E911.asc keyring/gpg/626471F1.asc
 
       - name: Download external toolchain/sdk
         if: inputs.build_toolchain == false && steps.parse-toolchain.outputs.toolchain-type != 'internal' && steps.parse-toolchain.outputs.toolchain-type != 'external_container'


### PR DESCRIPTION
This should increase the stability of the github CI system. Lately we
see that GPG key import is often failing or the signature check later
fails.
    
This is hopefully fixing problems like this:
```
Run gpg --receive-keys 0xCD84BCED626471F1 0x1D53D1877742E911 0xCD54E82DADB3684D
gpg: directory '/builder/.gnupg' created
gpg: keybox '/builder/.gnupg/pubring.kbx' created
gpg: keyserver receive failed: No keyserver available
Error: Process completed with exit code 2.
```
and this:
 ```
2025-08-08 23:12:40 (67.4 MB/s) - ‘sha256sums’ saved [10079047/10079047]
    
gpg: assuming signed data in 'sha256sums'
gpg: Signature made Fri 08 Aug 2025 10:12:51 AM UTC
gpg:                using EDDSA key 92C561DE55AE6552F3C736B82B0151090606D1D9
gpg: BAD signature from "OpenWrt Build System (Nitrokey3) <contact@openwrt.org>" [unknown]
Error: Process completed with exit code 1.
```

See examples here: 
https://github.com/openwrt/openwrt/actions/runs/16829825526/job/47695432598
https://github.com/openwrt/openwrt/actions/runs/16812198151/job/47633375739
https://github.com/openwrt/openwrt/actions/runs/16810638493/job/47633350017
https://github.com/openwrt/openwrt/actions/runs/16807864111/job/47629088613
https://github.com/openwrt/openwrt/actions/runs/16803431180/job/47608917051

I re triggered many of the failed runs manually in the last days. We see this problem about 10 times a day, the linked ones are megred anyway and do not need a rerun. 