### PR TITLE
CI: formal: make commit msessage check optional

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -2,6 +2,10 @@ name: Test Formalities
 
 on:
   workflow_call:
+    inputs:
+      check_commit_message:
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -59,11 +63,13 @@ jobs:
               RET=1
             fi
 
-            if echo "$body" | grep -v "Signed-off-by:"; then
-              success "A commit message exists"
-            else
-              err "Missing commit message. Please describe your changes"
-              RET=1
+            if [ ${{ inputs.check_commit_message }} == "true" ]; then
+              if echo "$body" | grep -v "Signed-off-by:"; then
+                success "A commit message exists"
+              else
+                err "Missing commit message. Please describe your changes"
+                RET=1
+              fi
             fi
           done
 


### PR DESCRIPTION
In openwrt/packages repo there are a lot of simple PRs like 'foo: update to 1.2.3'. A sufficient number of maintainers expressed regret with commit message check - it introduces friction and pollutes git history. To ease their pain we introduce boolean variable which allows to disable the check on the per-repo basis.