### PR TITLE
multi-arch-test-build: add fallback if openwrt-version is not found

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Determine branch name
         run: |
           BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+          if [[ "$BRANCH" != "master" && "$BRANCH" != "main" && ! "$BRANCH" =~ ^openwrt-[0-9]+\.[0-9]+$ ]]; then
+            BRANCH="master"
+          fi
           echo "Building for $BRANCH"
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 


### PR DESCRIPTION
This might be a rare case, but it happened when I forked the packages repository under my account, created a PR against the packages repository, and then someone created a PR against my feature branch, which I had submitted to the packages repository.

CI/CD was trying to look for target-featurebranch e.g. aarch64-generic-MyFeatureBranch and thus it failed:

buildx failed with: ERROR: failed to build: failed to solve: ghcr.io/openwrt/sdk:aarch64_generic-MyFeatureBranch: failed to resolve source metadata for ghcr.io/openwrt/sdk:aarch64_generic-MyFeatureBranch: ghcr.io/openwrt/sdk:aarch64_generic-MyFeatureBranch: not found

If there isn't an openwrt-version match, fall back to building for the OpenWrt master branch (snapshot builds).