### PR TITLE
tools: macos: Install Python 3.12

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -30,6 +30,7 @@ jobs:
         working-directory: ${{ env.WORKPATH }}/openwrt
         run: |
           brew install \
+            python@3.12 \
             automake \
             coreutils \
             diffutils \


### PR DESCRIPTION
OpenWrt looks for Python 3.12 or older. Brew only installs Python 3.13 and 3.14, but there is still a python 3.12 installed in the system. The OpenWrt build system will use the system Python instead, but we installed setuptools only for the brew version.

This fixes the following error in the MacOS build:
```
u-boot: Please install the Python3 setuptools module
```