### PR TITLE
multi-arch-test-build: generate build keys as needed

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -99,6 +99,7 @@ jobs:
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
       - name: Generate OPKG build keys
+        if: ${{ env.BRANCH == 'openwrt-24.10' || env.BRANCH == 'openwrt-23.05' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y signify-openbsd
@@ -109,6 +110,7 @@ jobs:
           echo "$EOF" >> $GITHUB_ENV
 
       - name: Generate APK build keys
+        if: ${{ env.BRANCH != 'openwrt-24.10' && env.BRANCH != 'openwrt-23.05' }}
         run: |
           openssl ecparam -name prime256v1 -genkey -noout -out packages-ci-private.pem
           openssl ec -in packages-ci-private.pem -pubout > packages-ci-public.pem


### PR DESCRIPTION
Generate either OPKG or APK build keys for respective branches only.

Example main job: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19068351506/job/54464546010?pr=1#step:6:1
Example 24.10 job: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19068339028/job/54464505092?pr=2#step:5:1

CC: @aparcar 