### PR TITLE
formal: refactor and unify formality checks

### DIFF
--- a/.github/scripts/check_formalities.sh
+++ b/.github/scripts/check_formalities.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+source workflow_context/.github/scripts/ci_helpers.sh
+
+RET=0
+for commit in $(git rev-list HEAD ^origin/"$BRANCH"); do
+	info "=== Checking commit '$commit'"
+	if git show --format='%P' -s "$commit" | grep -qF ' '; then
+		err "Pull request should not include merge commits"
+		RET=1
+	fi
+
+	author_name="$(git show -s --format=%aN "$commit")"
+	# Pattern \S\+\s\+\S\+ matches >= 2 names i.e. 3 and more e.g. "John Von
+	# Doe" also match
+	if echo "$author_name" | grep -q '\S\+\s\+\S\+'; then
+		success "Author name ($author_name) seems OK"
+	# Pattern \S\+ matches single names, typical of nicknames or handles
+	elif echo "$author_name" | grep -q '\S\+'; then
+		warn "Author name ($author_name) seems to be a nickname or an alias"
+	else
+		err "Author name ($author_name) must be one of:"
+		err "- real name 'firstname lastname' OR"
+		err '- nickname/alias/handle'
+		RET=1
+	fi
+
+	author_email="$(git show -s --format='%aE' "$commit")"
+	if echo "$author_email" | grep -qF "@users.noreply.github.com"; then
+		err "Author email cannot be a GitHub noreply email"
+		RET=1
+	else
+		success "Author email is not a GitHub noreply email"
+	fi
+
+	committer_name="$(git show -s --format=%cN "$commit")"
+	# Pattern \S\+\s\+\S\+ matches >= 2 names i.e. 3 and more e.g. "John Von
+	# Doe" also match
+	if echo "$committer_name" | grep -q '\S\+\s\+\S\+'; then
+		success "Committer name ($committer_name) seems OK"
+	# Pattern \S\+ matches single names, typical of nicknames or handles
+	elif echo "$committer_name" | grep -q '\S\+'; then
+		warn "Committer name ($committer_name) seems to be a nickname or an alias"
+	else
+		err "Committer name ($committer_name) must be one of:"
+		err "- real name 'firstname lastname' OR"
+		err '- nickname/alias/handle'
+		RET=1
+	fi
+
+	subject="$(git show -s --format=%s "$commit")"
+	if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_-]\+: ' -e '^Revert '; then
+		success "Commit subject line seems OK ($subject)"
+	elif echo "$subject" | grep -iq '^Translated using Weblate.*'; then
+		warn "Weblate commit subject line exception: $subject"
+	elif echo "$subject" | grep -iq '^Added translation using Weblate.*'; then
+		warn "Weblate commit subject line exception: $subject"
+	else
+		err "Commit subject line MUST start with '<package name>: ' ($subject)"
+		RET=1
+	fi
+
+	body="$(git show -s --format=%b "$commit")"
+	sob="$(git show -s --format='Signed-off-by: %aN <%aE>' "$commit")"
+	if echo "$body" | grep -qF "$sob"; then
+		success "Signed-off-by matches author"
+	elif echo "$author_email" | grep -iqF "<hosted@weblate.org>"; then
+		warn "Signed-off-by exception: authored by Weblate"
+	else
+		err "Signed-off-by is missing or doesn't match author (should be '$sob')"
+		RET=1
+	fi
+
+	if echo "$body" | grep -qF "@users.noreply.github.com"; then
+		err "Signed-off-by email cannot be a GitHub noreply email"
+		RET=1
+	else
+		success "Signed-off-by email is not a GitHub noreply email"
+	fi
+
+	if echo "$body" | grep -v "Signed-off-by:"; then
+		success "A commit message exists"
+	else
+		err "Commit message is missing. Please describe your changes."
+		RET=1
+	fi
+done
+
+exit $RET

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -11,10 +11,21 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout source code
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      - name: Checkout formalities
+        uses: actions/checkout@v5
+        with:
+          repository: openwrt/actions-shared-workflows
+          path: workflow_context
+          sparse-checkout: |
+            .github/scripts/ci_helpers.sh
+            .github/scripts/check_formalities.sh
+          sparse-checkout-cone-mode: false
 
       - name: Determine branch name
         run: |
@@ -23,48 +34,4 @@ jobs:
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
       - name: Test formalities
-        run: |
-          source .github/workflows/scripts/ci_helpers.sh
-
-          RET=0
-          for commit in $(git rev-list HEAD ^origin/$BRANCH); do
-            info "=== Checking commit '$commit'"
-            if git show --format='%P' -s $commit | grep -qF ' '; then
-              err "Pull request should not include merge commits"
-              RET=1
-            fi
-
-            author="$(git show -s --format=%aN $commit)"
-            if echo $author | grep -q '\S\+\s\+\S\+'; then
-              success "Author name ($author) seems ok"
-            else
-              err "Author name ($author) need to be your real name 'firstname lastname'"
-              RET=1
-            fi
-
-            subject="$(git show -s --format=%s $commit)"
-            if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_\.-]\+: ' -e '^Revert '; then
-              success "Commit subject line seems ok ($subject)"
-            else
-              err "Commit subject line MUST start with '<area>: ' ($subject)"
-              RET=1
-            fi
-
-            body="$(git show -s --format=%b $commit)"
-            sob="$(git show -s --format='Signed-off-by: %aN <%aE>' $commit)"
-            if echo "$body" | grep -qF "$sob"; then
-              success "Signed-off-by match author"
-            else
-              err "Signed-off-by is missing or doesn't match author (should be '$sob')"
-              RET=1
-            fi
-
-            if echo "$body" | grep -v "Signed-off-by:"; then
-              success "A commit message exists"
-            else
-              err "Missing commit message. Please describe your changes"
-              RET=1
-            fi
-          done
-
-          exit $RET
+        run: workflow_context/.github/scripts/check_formalities.sh


### PR DESCRIPTION
Formality checks are now unified into a single script that is meant to be shared between all the feeds.
    
Author and Signed-off-by email cannot be a GitHub noreply email as per the contributing guidelines. Which is a common issues in luci and packages feeds.
    
Add Weblate exceptions for the luci feed.
    
Extract the script to a separate file for easier maintainability and debugging.

Example failing job: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19117211025/job/54629195566?pr=3#step:5:7
Example passing job: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19117490411/job/54630136784?pr=3#step:5:7

TODO:
- [x] integrate luci feed checks