### PR TITLE
multi-arch-test-build: free up some diskspace

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -57,6 +57,13 @@ jobs:
             runtime_test: true
 
     steps:
+      - name: Remove unused Android SDK, .NET, Swift, GHC
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0


### PR DESCRIPTION
GitHub recently made their base builder image a lot bigger, leaving less disk space for us to work with. Based on earlier work in https://github.com/PowerDNS/pdns/pull/16409 which is working out well for us.
