### PR TITLE
formal: switch to single CPU runner

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Test Formalities
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
Based on a [recent comment](https://github.com/openwrt/actions-shared-workflows/pull/62#discussion_r2502707346), switch formality checks to use a lighter single CPU runner based on ubuntu-slim.

Example job: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19173172244/job/54810908707?pr=1