### PR TITLE
treewide: switch simple jobs to single CPU runner

### DIFF
--- a/.github/workflows/issue-labeller.yml
+++ b/.github/workflows/issue-labeller.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check-type:
     name: Parse Issue type
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     outputs:
       issue_type: ${{ steps.parse_labels.outputs.type }}
@@ -36,7 +36,7 @@ jobs:
     name: Validate and Tag Bug Report
     needs: check-type
     if: needs.check-type.outputs.issue_type == 'bug-report'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       issues: write
@@ -268,7 +268,7 @@ jobs:
   remove-labels:
     name: Remove Issue Labels
     needs: [ check-type, triage-bug-report ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       issues: write

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -16,7 +16,7 @@ jobs:
   determine_targets:
     name: Set targets
     needs: determine_changed_files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       targets_subtargets: ${{ steps.find_targets.outputs.targets_subtargets }}
       targets: ${{ steps.find_targets.outputs.targets }}

--- a/.github/workflows/label-kernel.yml
+++ b/.github/workflows/label-kernel.yml
@@ -8,7 +8,7 @@ jobs:
   set_target:
     if: startsWith(github.event.label.name, 'ci:kernel:')
     name: Set target
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       targets_subtargets: ${{ steps.set_target.outputs.targets_subtargets }}
       targets: ${{ steps.set_target.outputs.targets }}

--- a/.github/workflows/label-target.yml
+++ b/.github/workflows/label-target.yml
@@ -8,7 +8,7 @@ jobs:
   set_target:
     if: startsWith(github.event.label.name, 'ci:target:')
     name: Set target
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       target: ${{ steps.set_target.outputs.target }}
       subtarget: ${{ steps.set_target.outputs.subtarget }}

--- a/.github/workflows/push-containers.yml
+++ b/.github/workflows/push-containers.yml
@@ -7,7 +7,7 @@ jobs:
   determine-container-info:
     name: Determine needed info to push containers
     if: ${{ github.repository_owner  == 'openwrt' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       owner-lc: ${{ steps.generate-owner-lc.outputs.owner-lc }}
       container-tag: ${{ steps.determine-container-tag.outputs.container-tag }}
@@ -97,7 +97,7 @@ jobs:
   determine-targets:
     name: Set targets
     if: ${{ github.repository_owner  == 'openwrt' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       target: ${{ steps.find_targets.outputs.target }}
 

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -79,7 +79,7 @@ permissions:
 jobs:
   setup_build:
     name: Set up build ${{ inputs.target }}/${{ inputs.subtarget }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       container: ${{ steps.determine_container.outputs.container }}
       ccache_tag: ${{ steps.determine_ccache_tag.outputs.ccache_tag }}

--- a/.github/workflows/reusable_check-kernel-patches.yml
+++ b/.github/workflows/reusable_check-kernel-patches.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   setup_build:
     name: Set up build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       owner_lc: ${{ steps.lower_owner.outputs.owner_lc }}
       container_tag: ${{ steps.determine_tools_container.outputs.container_tag }}

--- a/.github/workflows/reusable_check-tools.yml
+++ b/.github/workflows/reusable_check-tools.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   determine-container-info:
     name: Determine needed info to push containers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       owner-lc: ${{ steps.generate-owner-lc.outputs.owner-lc }}
       container-tag: ${{ steps.determine-container-tag.outputs.container-tag }}

--- a/.github/workflows/reusable_determine_changed_files.yml
+++ b/.github/workflows/reusable_determine_changed_files.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   determine_changed_files:
     name: Determine Changed Files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       all_changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/reusable_determine_changed_packages.yml
+++ b/.github/workflows/reusable_determine_changed_packages.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   determine_changed_packages:
     name: Determine Changed Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       changed_packages: ${{ steps.get_packages.outputs.changed_packages }}
 

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   determine_targets:
     name: Set targets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       target: ${{ steps.find_targets.outputs.target }}
 


### PR DESCRIPTION
Switch simple jobs to use a single CPU runner based on ubuntu-slim.

I tried to pick simple-_looking_ jobs without any build or docker-related steps.

I've only tested building packages in the main feed.

Link: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners