### PR TITLE
multi-arch-test-build: don't sign packages

### DIFF
--- a/.github/dockerfiles_feeds/entrypoint.sh
+++ b/.github/dockerfiles_feeds/entrypoint.sh
@@ -8,17 +8,8 @@ mkdir -p /var/lock/
 mkdir -p /var/log/
 
 if [ $PKG_MANAGER = "opkg" ]; then
-	echo "src/gz packages_ci file:///ci" >> /etc/opkg/distfeeds.conf
-
-	FINGERPRINT="$(usign -F -p /ci/packages_ci.pub)"
-	cp /ci/packages_ci.pub "/etc/opkg/keys/$FINGERPRINT"
-
 	opkg update
 elif [ $PKG_MANAGER = "apk" ]; then
-	echo "/ci/packages.adb" >> /etc/apk/repositories.d/distfeeds.list
-
-	cp /ci/packages-ci-public.pem "/etc/apk/keys/"
-
 	apk update
 fi
 

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -98,35 +98,12 @@ jobs:
           echo "Building $PACKAGES"
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
-      - name: Generate OPKG build keys
-        if: ${{ env.BRANCH == 'openwrt-24.10' || env.BRANCH == 'openwrt-23.05' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y signify-openbsd
-          signify-openbsd -G -n -c 'DO NOT USE - OpenWrt packages feed CI' -p packages_ci.pub -s packages_ci.sec
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "KEY_BUILD<<$EOF" >> $GITHUB_ENV
-          cat packages_ci.sec >> $GITHUB_ENV
-          echo "$EOF" >> $GITHUB_ENV
-
-      - name: Generate APK build keys
-        if: ${{ env.BRANCH != 'openwrt-24.10' && env.BRANCH != 'openwrt-23.05' }}
-        run: |
-          openssl ecparam -name prime256v1 -genkey -noout -out packages-ci-private.pem
-          openssl ec -in packages-ci-private.pem -pubout > packages-ci-public.pem
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "PRIVATE_KEY<<$EOF" >> $GITHUB_ENV
-          cat packages-ci-private.pem >> $GITHUB_ENV
-          echo "$EOF" >> $GITHUB_ENV
-
       - name: Build
         uses: openwrt/gh-action-sdk@v9
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: packages_ci
           INDEX: 1
-          KEY_BUILD: ${{ env.KEY_BUILD }}
-          PRIVATE_KEY: ${{ env.PRIVATE_KEY }}
           V: s
 
       - name: Move created packages to project dir


### PR DESCRIPTION
Don't generate singing keys both for OPKG and APK and don't sign packages.

Depends on:
- [x] https://github.com/openwrt/gh-action-sdk/pull/56
    Otherwise the toolchain always tries to sign OPKG packages.

Main branch test: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19200927341/job/54888744771?pr=7#step:16:29
24.10 branch test: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19200333878/job/54887191162?pr=2#step:16:48