### PR TITLE
multi-arch-test-build: fix local index

### DIFF
--- a/.github/dockerfiles_feeds/entrypoint.sh
+++ b/.github/dockerfiles_feeds/entrypoint.sh
@@ -8,8 +8,10 @@ mkdir -p /var/lock/
 mkdir -p /var/log/
 
 if [ $PKG_MANAGER = "opkg" ]; then
+	echo "src/gz packages_ci file:///ci" >> /etc/opkg/distfeeds.conf
 	opkg update
 elif [ $PKG_MANAGER = "apk" ]; then
+	echo "/ci/packages.adb" >> /etc/apk/repositories.d/distfeeds.list
 	apk update
 fi
 


### PR DESCRIPTION
Fix adding packages build inside the CI to the the package index.

Fixes: 02f3958 ("multi-arch-test-build: don't sign packages")

Fixes the regression I introduced in: #66 :facepalm: 

Tested with interdependent packages in the same job: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19336650777/job/55313403861?pr=9#step:17:1

cc: @aparcar 