### PR TITLE
formal: improve messaging

### DIFF
--- a/.github/scripts/check_formalities.sh
+++ b/.github/scripts/check_formalities.sh
@@ -140,15 +140,16 @@ check_subject() {
 	# Check subject length first for hard limit which results in an error and
 	# otherwise for a soft limit which results in a warning. Show soft limit in
 	# either case.
+	local msg="Commit subject length: recommended max $MAX_SUBJECT_LEN_SOFT, required max $MAX_SUBJECT_LEN_HARD characters"
 	if [ ${#subject} -gt "$MAX_SUBJECT_LEN_HARD" ]; then
-		output_fail "Commit subject line is longer than $MAX_SUBJECT_LEN_SOFT characters (is ${#subject})"
+		output_fail "$msg"
 		split_fail "$MAX_SUBJECT_LEN_SOFT" "$subject"
 		RET=1
 	elif [ ${#subject} -gt "$MAX_SUBJECT_LEN_SOFT" ]; then
-		output_warn "Commit subject line is longer than $MAX_SUBJECT_LEN_SOFT characters (is ${#subject})"
+		output_warn "$msg"
 		split_fail "$MAX_SUBJECT_LEN_SOFT" "$subject"
 	else
-		status_pass "Commit subject line is $MAX_SUBJECT_LEN_SOFT characters or less"
+		status_pass "$msg"
 	fi
 }
 


### PR DESCRIPTION
Make commit subject line length check message clearer by specifying both soft and hard limits. The limits are still the same.

<img width="569" height="56" alt="image" src="https://github.com/user-attachments/assets/5b015f31-abbe-478d-88ec-9140fb710e97" />

Related discussion:
- https://github.com/openwrt/actions-shared-workflows/pull/64

cc: @Ansuel, @BKPepe, @hnyman, @jalakas, @namiltd