### PR TITLE
formal: fix commit subject and body check

### DIFF
--- a/.github/scripts/check_formalities.sh
+++ b/.github/scripts/check_formalities.sh
@@ -194,7 +194,7 @@ check_body() {
 		status_pass '`Signed-off-by` email is not a GitHub noreply email'
 	fi
 
-	if echo "$body" | grep -qv "Signed-off-by:"; then
+	if echo "$body" | grep -v "Signed-off-by:" | grep -qv '^[[:space:]]*$'; then
 		status_pass 'A commit message exists'
 	else
 		output_fail 'Commit message is missing. Please describe your changes.'


### PR DESCRIPTION
Base has commits with multiple prefixes in the form of:
```
generic: 6.18: remove obsolete backport patches
```

Adjust the prefix checks to accommodate for it.

Fix checking commit bodies that consist of whitespace only and shouldn't pass the test.

Sample run: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19829704764/job/56812288040?pr=1#step:4:1

Related:
- #64

cc: @aparcar, @namiltd, @robimarko