### PR TITLE
multi-arch-test-build: fix opkg-related CI issues

### DIFF
--- a/.github/dockerfiles_feeds/entrypoint.sh
+++ b/.github/dockerfiles_feeds/entrypoint.sh
@@ -9,6 +9,10 @@ mkdir -p /var/log/
 
 if [ $PKG_MANAGER = "opkg" ]; then
 	echo "src/gz packages_ci file:///ci" >> /etc/opkg/distfeeds.conf
+	# Disable checking signature for all opkg feeds, since it doesn't look like
+	# it's possible to do it for the local feed only, which has signing removed.
+	# This fixes running CI tests.
+	sed -i '/check_signature/d' /etc/opkg.conf
 	opkg update
 elif [ $PKG_MANAGER = "apk" ]; then
 	echo "/ci/packages.adb" >> /etc/apk/repositories.d/distfeeds.list

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -113,7 +113,7 @@ jobs:
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
       - name: Build
-        uses: openwrt/gh-action-sdk@v9
+        uses: openwrt/gh-action-sdk@v10
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: packages_ci


### PR DESCRIPTION
Update gh-action-sdk to v10 that fixes building OPKG package index with no keys being set, otherwise the toolchain always tries to sign packages.

Disable checking signature for all opkg feeds, since it doesn't look like it's possible to do it for the local feed only, which has signing removed. This fixes running CI tests.

Sample run:
- main: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19840921650/job/56849062492?pr=13#step:17:1
- 24.10: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/19839978173/job/56848114335?pr=2#step:17:1

Related:

- https://github.com/openwrt/gh-action-sdk/issues/57

Fixes: 02f3958 ("multi-arch-test-build: don't sign packages")

cc: @robimarko, @nmeyerhans