### PR TITLE
multi-arch-test-build: disable runtime testing on mips_24kc

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -33,7 +33,8 @@ jobs:
 
           - arch: mips_24kc
             target: ath79-generic
-            runtime_test: true
+            # Temporarily disabled due to random "Bus error (core dumped)" errors
+            runtime_test: false
 
           - arch: mipsel_24kc
             target: mt7621


### PR DESCRIPTION
mips_24kc runtime testing is currently constantly failling with: Bus error (core dumped)

This is misleading for contributors as it might seems like the issue is with their changes.

So, until we fix the root cause, lets disable runtime testing on mips_24kc.

Related issue: https://github.com/openwrt/docker/issues/185