### PR TITLE
CI: reusable_build: implement HACK to freeup some space in Host Image

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -272,7 +272,9 @@ jobs:
     needs: setup_build
     runs-on: ubuntu-latest
 
-    container: ghcr.io/${{ needs.setup_build.outputs.container }}
+    container:
+      image: ghcr.io/${{ needs.setup_build.outputs.container }}
+      options: --privileged --pid=host
 
     permissions:
       contents: read
@@ -280,6 +282,16 @@ jobs:
       actions: write
 
     steps:
+      - name: Free up some space in Host Github Image
+        shell: sh -c "nsenter -t 1 -a sh -e /home/runner/$(echo {0} | sed s#^/__w#work#)"
+        env:
+          DELETE_DIR: /usr/local/lib/android /usr/local/.ghcup /usr/share/dotnet /usr/share/swift
+        run: |
+          mkdir /empty
+          for dir in $DELETE_DIR; do
+            sudo rsync -a --delete /empty/ $dir
+          done
+
       - name: Checkout master directory
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Implement an HACK to freeup some space in the Github Host Image.

It was discovered that lots of space is wasted by all the dependency installed by default in the ubuntu-latest image and it's not possible to delete them when the workflow is run directly with a container image.

To handle this we run the container in privileged mode and assing the same pid of the host machine.

This way with the help of the nsenter command and some magic/reverse of the Github Action shell variable, we can execute command directly in the host machine permiting to delete all kind of unwanted files.

This permits to gain extra space of about 20+ GB by removing Android Swift and dotnet files.

We use rsync with the empty directory to speed up deletion of all these files (normal rm takes 2 minutes with rsync taking max 30-40 seconds)