### PR TITLE
reusable_build: fix toolchain file parsing

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -384,7 +384,7 @@ jobs:
           fi
 
           echo "TOOLCHAIN_FILE=$TOOLCHAIN_FILE" >> "$GITHUB_ENV"
-          echo "TOOLCHAIN_NAME=$(echo TOOLCHAIN_FILE | sed -E -e 's/.tar.(xz|zst)$//')" >> "$GITHUB_ENV"
+          echo "TOOLCHAIN_NAME=$(echo $TOOLCHAIN_FILE | sed -E -e 's/.tar.(xz|zst)$//')" >> "$GITHUB_ENV"
 
       - name: Prase prebuilt llvm file
         if: inputs.build_toolchain == false


### PR DESCRIPTION
Currently, we are echoing TOOLCHAIN_FILE as a string instead of its content to set TOOLCHAIN_NAME variable, which will make the CI fail with: Toolchain directory 'TOOLCHAIN_FILE/toolchain-*' does not exist.

As TOOLCHAIN_NAME variable value will be exactly: "TOOLCHAIN_FILE" which obviously is not correct.

Fixes: 6ed08160094d ("CI: reusable-build: support both .xz and .zst compression")