### PR TITLE
reusable_build: improve ccahe handling

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -692,6 +692,14 @@ jobs:
         working-directory: openwrt
         run: make target/toolchain/compile -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
 
+      - name: Show ccache stats
+        if: inputs.use_ccache_cache == true
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/openwrt/.ccache
+        run: staging_dir/host/bin/ccache --show-stats
+
       - name: Coverity prepare toolchain
         if: inputs.coverity_check_packages != ''
         shell: su buildbot -c "sh -e {0}"

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -546,7 +546,7 @@ jobs:
           touch $SYSTEM_CCACHE_CONF
 
           echo compiler_type=gcc >> $SYSTEM_CCACHE_CONF
-          [ ${{ inputs.ccache_type }} = 'kernel' ] && echo max_size=400M >> $SYSTEM_CCACHE_CONF
+          [ ${{ inputs.ccache_type }} = 'kernel' ] && echo max_size=800M >> $SYSTEM_CCACHE_CONF
 
           echo depend_mode=true >> $SYSTEM_CCACHE_CONF
           echo sloppiness=file_macro,locale,time_macros >> $SYSTEM_CCACHE_CONF

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -401,7 +401,8 @@ jobs:
 
       - name: Download and extract ccache cache from s3
         id: restore-ccache-cache-s3
-        if: inputs.use_ccache_cache == true
+        if: inputs.use_ccache_cache == true &&
+            ( inputs.ccache_type != 'kernel' || inputs.upload_ccache_cache != true)
         working-directory: openwrt
         run: |
           S3_LINK=https://s3-ccache.openwrt-ci.ansuel.com
@@ -436,7 +437,9 @@ jobs:
 
       - name: Restore ccache cache
         id: restore-ccache-cache
-        if: inputs.use_ccache_cache == true && steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
+        if: inputs.use_ccache_cache == true &&
+            ( inputs.ccache_type != 'kernel' || inputs.upload_ccache_cache != true) &&
+            steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
         uses: actions/cache/restore@v5
         with:
           path: openwrt/.ccache


### PR DESCRIPTION
 * reusable_build: show ccache statistics after build
    
    Add a step to print the ccache hit rate, miss rate, and cache size
    after each build. This makes it easy to verify that the cache is
    being populated and used correctly.

 * reusable_build: increase kernel ccache size limit to 800M
    
    The previous limit of 400M was too small to hold a complete kernel
    build. A cold build of kernel 6.12 for ipq40xx/generic fills the
    cache to 659M, which means ccache was evicting entries mid-build.
    Those evicted entries would then be cache misses on the next build,
    reducing the hit rate and defeating the purpose of the cache. Increase
    the limit to 800M to fit a full kernel build and maximize hits on
    subsequent builds.
    
    Measured cache usage after a cold kernel 6.12 build for ipq40xx/generic:
    
    ```
    buildbot@013d604d7d26:/openwrt$ du -sh .ccache/
    659M    .ccache/
    buildbot@013d604d7d26:/openwrt$ CCACHE_DIR=.ccache staging_dir/host/bin/ccache --show-stats
    Cacheable calls:    5842 / 5955 (98.10%)
      Hits:               43 / 5842 ( 0.74%)
        Direct:           43 /   43 (100.0%)
        Preprocessed:      0 /   43 ( 0.00%)
      Misses:           5799 / 5842 (99.26%)
    Uncacheable calls:   113 / 5955 ( 1.90%)
    Local storage:
      Cache size (GiB):  0.6 /  5.0 (12.82%)
      Hits:               43 / 5842 ( 0.74%)
      Misses:           5799 / 5842 (99.26%)
    ```
   
* reusable_build: use fresh ccache when upload_ccache_cache is set
    
    When upload_ccache_cache is enabled, skip restoring the existing cache
    from S3 and GitHub Actions before building. This ensures the uploaded
    cache only contains entries from the current build, without
    accumulating stale entries from previous builds that may no longer be
    relevant (e.g. after a kernel version bump). A smaller, fresher cache
    is faster to download and more effective than a large cache polluted
    with obsolete entries.