### PR TITLE
check_formalities.sh: increase line length limits

### DIFF
--- a/.github/scripts/check_formalities.sh
+++ b/.github/scripts/check_formalities.sh
@@ -2,9 +2,9 @@
 
 # Based on https://openwrt.org/submitting-patches#submission_guidelines
 # Hard limit is arbitrary
-MAX_SUBJECT_LEN_HARD=60
-MAX_SUBJECT_LEN_SOFT=50
-MAX_BODY_LINE_LEN=75
+MAX_SUBJECT_LEN_HARD=80
+MAX_SUBJECT_LEN_SOFT=60
+MAX_BODY_LINE_LEN=100
 
 DEPENDABOT_EMAIL="dependabot[bot]@users.noreply.github.com"
 GITHUB_NOREPLY_EMAIL='@users.noreply.github.com'


### PR DESCRIPTION
The previous limits were based on RFC 822 from 1982 and are too restrictive for modern development workflows.
Increase the hard subject length limit from 60 to 80 characters and the soft limit from 50 to 60, as a 50-character title often forces developers to omit useful context. Also raise the body line length from 75 to 100 characters, since most terminals and code review tools today support much wider displays than the original 80-column standard.