### PR TITLE
CI: bump github actions to recent versions

### DIFF
--- a/.github/workflows/issue-labeller.yml
+++ b/.github/workflows/issue-labeller.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Post Invalid Version
         if: steps.check_version.outputs.invalid_version == 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{repository}/issues/{issue_number}/comments
           body: ${{ toJSON(env.REQUEST_BODY) }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Post Invalid Release
         if: steps.check_release.outputs.invalid_release == 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{repository}/issues/{issue_number}/comments
           body: ${{ toJSON(env.REQUEST_BODY) }}
@@ -172,7 +172,7 @@ jobs:
 
       - name: Post Invalid Target/Subtarget
         if: steps.check_target.outputs.invalid_target == 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{repository}/issues/{issue_number}/comments
           body: ${{ toJSON(env.REQUEST_BODY) }}
@@ -188,7 +188,7 @@ jobs:
       # and model name set in image.mk
       # - name: Post Invalid Model
       #   if: steps.check_device.outputs.invalid_device == 'true'
-      #   uses: octokit/request-action@v2.x
+      #   uses: octokit/request-action@v3
       #   with:
       #     route: POST /repos/{repository}/issues/{issue_number}/comments
       #     body: ${{ toJSON(env.REQUEST_BODY) }}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Add Release tag
         if: steps.check_version.outputs.invalid_version != 'true' && steps.check_release.outputs.invalid_release != 'true' && steps.check_target.outputs.invalid_target != 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{repository}/issues/{issue_number}/labels
           labels: ${{ env.REQUEST_BODY }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Add Target/Subtarget tag
         if: steps.check_version.outputs.invalid_version != 'true' && steps.check_release.outputs.invalid_release != 'true' && steps.check_target.outputs.invalid_target != 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{repository}/issues/{issue_number}/labels
           labels: ${{ env.REQUEST_BODY }}
@@ -228,7 +228,7 @@ jobs:
 
       - name: Add tag Image Kind
         if: steps.check_version.outputs.invalid_version != 'true' && steps.check_release.outputs.invalid_release != 'true' && steps.check_target.outputs.invalid_target != 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{repository}/issues/{issue_number}/labels
           labels: ${{ env.REQUEST_BODY }}
@@ -241,7 +241,7 @@ jobs:
 
       - name: Add tag Supported Device
         if: steps.check_version.outputs.invalid_version != 'true' && steps.check_release.outputs.invalid_release != 'true' && steps.check_target.outputs.invalid_target != 'true' && steps.check_device.outputs.invalid_device != 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{repository}/issues/{issue_number}/labels
           labels: ${{ env.REQUEST_BODY }}
@@ -254,7 +254,7 @@ jobs:
 
       - name: Add Invalid Tag
         if: steps.check_version.outputs.invalid_version == 'true' || steps.check_release.outputs.invalid_release == 'true' || steps.check_target.outputs.invalid_target == 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{repository}/issues/{issue_number}/labels
           labels: ${{ env.REQUEST_BODY }}
@@ -275,7 +275,7 @@ jobs:
 
     steps:
       - name: Remove tag to-triage
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: DELETE /repos/{repository}/issues/{issue_number}/labels/{issue_label}
         env:
@@ -285,7 +285,7 @@ jobs:
           INPUT_ISSUE_LABEL: to-triage
 
       - name: Remove tag issue type
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: DELETE /repos/{repository}/issues/{issue_number}/labels/{issue_label}
         env:

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -769,7 +769,7 @@ jobs:
       - name: Delete already present ccache cache
         if: steps.restore-ccache-cache.outputs.cache-hit == 'true' && inputs.use_ccache_cache == true  &&
           github.event_name == 'push' && steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: DELETE /repos/{repository}/actions/caches?key={key}
         env:


### PR DESCRIPTION
 * CI: Bump actions/upload-artifact from 6 to 7
    
    v7 adds support for direct (unzipped) single-file uploads via a new
    `archive: false` parameter and migrates the package to ESM internally.
    Both changes are transparent to existing usage — no inputs, outputs, or
    behaviour of the action change for callers that do not use the new
    parameter.
    
    Release notes: https://github.com/actions/upload-artifact/releases/tag/v7.0.0
    
 * CI: Bump actions/download-artifact from 7 to 8
    
    v8 migrates the package to ESM and adds support for direct (unzipped)
    downloads to match the new upload-artifact direct upload feature.
    
    One behaviour change: hash mismatches now error by default instead of
    logging a warning. This is safe for correct workflows where artifact
    content does not change between upload and download.
    
    Release notes: https://github.com/actions/download-artifact/releases/tag/v8.0.0
   
 * CI: Bump actions/github-script from 8 to 9
    
    v9 upgrades to @actions/github v9 (ESM-only) and adds a getOctokit
    factory function directly to the script context.
    
    Breaking change: require('@actions/github') no longer works in inline
    scripts. The only usage here passes github and context as parameters to
    a local CommonJS module (process_formalities.js) which does not import
    @actions/github itself, so the upgrade is safe.
    
    Release notes: https://github.com/actions/github-script/releases/tag/v9.0.0

 * CI: Bump docker/login-action from 3 to 4 and docker/build-push-action from 6 to 7
    
    Both actions update their runtime to Node 24 (requires Actions Runner
    v2.327.1+) and migrate to ESM internally. No changes to inputs, outputs,
    or behaviour for existing callers.
    
    docker/build-push-action v7 additionally removes two deprecated
    environment variables (DOCKER_BUILD_NO_SUMMARY,
    DOCKER_BUILD_EXPORT_RETENTION_DAYS) which are not used in these
    workflows.
    
    Release notes:
    - https://github.com/docker/login-action/releases/tag/v4.0.0
    - https://github.com/docker/build-push-action/releases/tag/v7.0.0
   
 * CI: Bump octokit/request-action from 2.x to 3
    
    v3 updates the runtime to Node 24 (requires Actions Runner v2.327.1+)
    and switches the build from NCC to ESBuild. No changes to inputs,
    outputs, or behaviour for callers.
    
    Release notes: https://github.com/octokit/request-action/releases/tag/v3.0.0