### PR TITLE
Fix ccache handling

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -534,6 +534,15 @@ jobs:
           echo CONFIG_TARGET_PER_DEVICE_ROOTFS=y >> .config
           echo CONFIG_TARGET_ALL_PROFILES=y >> .config
 
+      - name: Export ccache environment
+        if: inputs.use_ccache_cache == true
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/openwrt/.ccache
+          CCACHE_CONFIGPATH2: ${{ github.workspace }}/openwrt/staging_dir/host/etc/ccache.conf
+        run: |
+          echo "CCACHE_DIR=$CCACHE_DIR" >> "$GITHUB_ENV"
+          echo "CCACHE_CONFIGPATH2=$CCACHE_CONFIGPATH2" >> "$GITHUB_ENV"
+
         # ccache for some reason have problem detecting compiler type
         # with external toolchain. This cause the complete malfunction
         # of ccache with the result of tons of unsupported compiler
@@ -543,16 +552,14 @@ jobs:
         if: inputs.use_ccache_cache == true
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        env:
-          SYSTEM_CCACHE_CONF: staging_dir/host/etc/ccache.conf
         run: |
-          touch $SYSTEM_CCACHE_CONF
+          touch $CCACHE_CONFIGPATH2
 
-          echo compiler_type=gcc >> $SYSTEM_CCACHE_CONF
-          [ ${{ inputs.ccache_type }} = 'kernel' ] && echo max_size=800M >> $SYSTEM_CCACHE_CONF
+          echo compiler_type=gcc >> $CCACHE_CONFIGPATH2
+          [ ${{ inputs.ccache_type }} = 'kernel' ] && echo max_size=800M >> $CCACHE_CONFIGPATH2
 
-          echo depend_mode=true >> $SYSTEM_CCACHE_CONF
-          echo sloppiness=file_macro,locale,time_macros >> $SYSTEM_CCACHE_CONF
+          echo depend_mode=true >> $CCACHE_CONFIGPATH2
+          echo sloppiness=file_macro,locale,time_macros >> $CCACHE_CONFIGPATH2
 
           echo CONFIG_CCACHE=y >> .config
 
@@ -699,8 +706,6 @@ jobs:
         if: inputs.use_ccache_cache == true
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        env:
-          CCACHE_DIR: ${{ github.workspace }}/openwrt/.ccache
         run: staging_dir/host/bin/ccache --show-stats
 
       - name: Coverity prepare toolchain

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -557,7 +557,8 @@ jobs:
           touch $CCACHE_CONFIGPATH2
 
           echo compiler_type=gcc >> $CCACHE_CONFIGPATH2
-          [ ${{ inputs.ccache_type }} = 'kernel' ] && echo max_size=800M >> $CCACHE_CONFIGPATH2
+          [ ${{ inputs.ccache_type }} = 'kernel' ] && echo max_size=1G >> $CCACHE_CONFIGPATH2
+          [ ${{ inputs.ccache_type }} = 'packages' ] && echo max_size=8G >> $CCACHE_CONFIGPATH2
 
           echo depend_mode=true >> $CCACHE_CONFIGPATH2
           echo sloppiness=file_macro,locale,time_macros,include_file_ctime,include_file_mtime >> $CCACHE_CONFIGPATH2

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -296,6 +296,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: openwrt
+          fetch-depth: 0
 
       - name: Checkout packages feed
         if: inputs.include_feeds == true
@@ -649,6 +650,27 @@ jobs:
         working-directory: openwrt
         run: |
           echo CONFIG_USE_LLVM_PREBUILT=y >> .config
+
+      - name: Determine ccache compiler_check
+        if: inputs.use_ccache_cache == true
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          REV=HEAD
+          TOOLCHAIN_NAME=in-tree
+          if [ "${{ inputs.build_toolchain }}" != "true" ] && [ -d /external-toolchain ]; then
+            GCC=$(find /external-toolchain -name '*-openwrt-linux-*-gcc' \( -type f -o -type l \) 2>/dev/null | head -n1)
+            if [ -n "$GCC" ]; then
+              TOOLCHAIN_REV=$("$GCC" --version | head -n1 | grep -oE 'r[0-9]+-[0-9a-f]+' | sed 's/^r[0-9]*-//')
+              git cat-file -e "$TOOLCHAIN_REV" 2>/dev/null && REV=$TOOLCHAIN_REV
+              TOOLCHAIN_NAME=$(basename "$(dirname "$(dirname "$GCC")")")
+            fi
+          fi
+
+          SHA=$(git log -1 --format=%H "$REV" -- toolchain/gcc/ toolchain/binutils/)
+          echo "Using toolchain rev $REV -> last toolchain change $SHA ($TOOLCHAIN_NAME)"
+
+          echo "compiler_check=string:$SHA:$TOOLCHAIN_NAME" >> $CCACHE_CONFIGPATH2
 
       - name: Show configuration
         shell: su buildbot -c "sh -e {0}"

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -565,6 +565,12 @@ jobs:
 
           echo CONFIG_CCACHE=y >> .config
 
+      - name: Reset ccache stats
+        if: inputs.use_ccache_cache == true
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: staging_dir/host/bin/ccache --zero-stats
+
       - name: Configure external toolchain in container
         if: inputs.build_toolchain == false && steps.parse-toolchain.outputs.toolchain-type == 'external_container'
         shell: su buildbot -c "sh -e {0}"
@@ -729,7 +735,7 @@ jobs:
         if: inputs.use_ccache_cache == true
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        run: staging_dir/host/bin/ccache --show-stats
+        run: staging_dir/host/bin/ccache -vv --show-stats
 
       - name: Coverity prepare toolchain
         if: inputs.coverity_check_packages != ''

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -788,6 +788,14 @@ jobs:
           name: ${{ inputs.target }}-${{ inputs.subtarget }}${{ inputs.testing == true && '-testing' || '' }}-logs
           path: "openwrt/logs"
 
+      - name: Cleanup ccache
+        if: inputs.use_ccache_cache == true && github.event_name == 'push'
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          staging_dir/host/bin/ccache --evict-older-than 1d
+          staging_dir/host/bin/ccache --cleanup
+
       - name: Cleanup dl/build_dir/staging_dir to make some space
         working-directory: openwrt
         if: github.event_name == 'push'
@@ -817,7 +825,7 @@ jobs:
           inputs.upload_ccache_cache == true
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        run: tar -cf ${{ needs.setup_build.outputs.ccache_name }}.tar .ccache
+        run: tar --exclude='.ccache/tmp' -cf ${{ needs.setup_build.outputs.ccache_name }}.tar .ccache
 
       - name: Upload ccache cache
         if: inputs.use_ccache_cache == true && github.event_name == 'push' &&

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -559,7 +559,7 @@ jobs:
           [ ${{ inputs.ccache_type }} = 'kernel' ] && echo max_size=800M >> $CCACHE_CONFIGPATH2
 
           echo depend_mode=true >> $CCACHE_CONFIGPATH2
-          echo sloppiness=file_macro,locale,time_macros >> $CCACHE_CONFIGPATH2
+          echo sloppiness=file_macro,locale,time_macros,include_file_ctime,include_file_mtime >> $CCACHE_CONFIGPATH2
 
           echo CONFIG_CCACHE=y >> .config
 


### PR DESCRIPTION
This contains multiple fixes and improvements for the ccache handling in the Github actions. This is very hard to test in all the situations. I hope this fixes the ccache handling in the github actions now. 

For small changes it should reduce the build time of  a Linux kernel from 25 minutes to 2:30 minutes.

Here is an example run on main: https://github.com/hauke/openwrt/actions/runs/24610733561/job/71964583220
and here on a PR: https://github.com/hauke/openwrt/actions/runs/24612062608/job/71968121620

This also needs this OpenWrt change: https://github.com/openwrt/openwrt/pull/22995