### PR TITLE
Claude code routines update

### DIFF
--- a/llm-review-prompts/llm-nightly-digest.md
+++ b/llm-review-prompts/llm-nightly-digest.md
@@ -87,9 +87,16 @@ The API caller passes structured key=value lines in the `text` field. Example:
    sub-agents are told to check for existence before grepping. If
    `extra_repos` is empty, skip this step entirely.
 
-3. **Spawn sub-agents in parallel.** For each PR number in `pr_numbers`,
-   spawn one sub-agent via the Agent tool. Issue all spawn calls
-   in a **single message** so the runtime can execute them concurrently.
+   **Wait for every `git clone` to finish before proceeding to step
+   3.** Sub-agents read these directories the moment they start, so
+   spawning them while a clone is still in flight will race them
+   against an empty or partial tree.
+
+3. **Spawn sub-agents in parallel.** Only after step 2 has fully
+   completed (all clones returned, successfully or with the failure
+   logged), for each PR number in `pr_numbers` spawn one sub-agent
+   via the Agent tool. Issue all spawn calls in a **single message**
+   so the runtime can execute them concurrently.
 
    For each sub-agent, pass the prompt template below verbatim, after
    substituting `<NUM>` with the PR number, `<REPO>` with the value of

--- a/llm-review-prompts/llm-nightly-digest.md
+++ b/llm-review-prompts/llm-nightly-digest.md
@@ -176,6 +176,29 @@ The API caller passes structured key=value lines in the `text` field. Example:
 
    6. **Review along three dimensions:**
 
+      **Backport / cherry-pick PRs.** First, check whether this is
+      a backport: PR title starts with `[X.Y]` (e.g. `[25.12]`),
+      the base branch matches `openwrt-NN.NN`, or any commit
+      carries a `(cherry picked from commit <sha>)` trailer. If
+      so, the inline-issue and nits scope shifts:
+
+      - **Do** flag: missing/wrong `(cherry picked from commit
+        <sha>)` trailer (`git cherry-pick -x` adds it
+        automatically); hunks that diverge from the upstream
+        commit on main; missing prerequisite commits the backport
+        depends on.
+      - **Do not** flag: code-style, convention, sister-device
+        parity, or design issues that already exist on the
+        upstream commit. Those belong on a fix-to-main PR, not on
+        the backport. The reviewer's premise is "this diff matches
+        main"; point out only deviations introduced by the
+        backport itself.
+
+      To find the upstream commit, use the `cherry picked from`
+      trailer if present; otherwise `git fetch origin main && git
+      log origin/main --grep='<subject>'`. Compare with `git show
+      <upstream-sha>`. Commit checks (next dimension) still apply.
+
       **Confidence policy (applies to all three dimensions).**
       Post any finding you have specific evidence for in the diff
       or in-tree files. When you have evidence but cannot verify
@@ -213,6 +236,15 @@ The API caller passes structured key=value lines in the `text` field. Example:
         what's wrong, not what could be different. Do not repeat
         the line. Skip lines you already commented on if your
         previous comment is still valid (don't duplicate).
+
+        When a fix needs a regenerated artifact (patch refresh,
+        kconfig regen, codegen, autotools, lockfile), only
+        prescribe a specific command if `.github/llm-review-rules.md`
+        documents one for this project. Otherwise describe the
+        desired end-state ("regenerate this patch so the hunk
+        headers match the new context") and let the maintainer
+        pick the tool — projects often have their own wrapper
+        around the obvious one.
 
         Don't flag pure style preferences (your taste vs theirs).
         Do flag deviations from the existing style of the file

--- a/llm-review-prompts/llm-pr-review.md
+++ b/llm-review-prompts/llm-pr-review.md
@@ -116,6 +116,27 @@ fully automated routine, not a helpful assistant looking for work to do.
 
 5. **Review along three dimensions:**
 
+   **Backport / cherry-pick PRs.** First, check whether this is a
+   backport: PR title starts with `[X.Y]` (e.g. `[25.12]`), the
+   base branch matches `openwrt-NN.NN`, or any commit carries a
+   `(cherry picked from commit <sha>)` trailer. If so, the
+   inline-issue and nits scope shifts:
+
+   - **Do** flag: missing/wrong `(cherry picked from commit <sha>)`
+     trailer (`git cherry-pick -x` adds it automatically); hunks
+     that diverge from the upstream commit on main; missing
+     prerequisite commits the backport depends on.
+   - **Do not** flag: code-style, convention, sister-device parity,
+     or design issues that already exist on the upstream commit.
+     Those belong on a fix-to-main PR, not on the backport. The
+     reviewer's premise is "this diff matches main"; point out only
+     deviations introduced by the backport itself.
+
+   To find the upstream commit, use the `cherry picked from` trailer
+   if present; otherwise `git fetch origin main && git log
+   origin/main --grep='<subject>'`. Compare with `git show
+   <upstream-sha>`. Commit checks (next dimension) still apply.
+
    **Confidence policy (applies to all three dimensions below).** Post
    any finding you have specific evidence for in the diff or in-tree
    files. When you have evidence but cannot verify with certainty
@@ -147,6 +168,14 @@ fully automated routine, not a helpful assistant looking for work to do.
      concurrency issues, off-by-one, unclear logic, project convention
      violations. One concrete suggestion per inline comment. Lead with
      what's wrong, not what could be different. Do not repeat the line.
+
+     When a fix needs a regenerated artifact (patch refresh, kconfig
+     regen, codegen, autotools, lockfile), only prescribe a specific
+     command if `.github/llm-review-rules.md` documents one for this
+     project. Otherwise describe the desired end-state ("regenerate
+     this patch so the hunk headers match the new context") and let
+     the maintainer pick the tool — projects often have their own
+     wrapper around the obvious one.
 
      Don't flag pure style preferences (your taste vs theirs). Do flag
      deviations from the existing style of the file being changed or of


### PR DESCRIPTION
 * CI: tighten LLM review prompts based on early feedback
    
    Two recurring categories of bot misfire on the first PRs:
    
    1. Backports/cherry-picks were reviewed as if they were fresh
       patches — code-style/design nits flagged on hunks that exist
       verbatim on main were rejected by maintainers ("this is a
       cherry pick, please keep it as in main").
    2. Suggesting fix commands the bot had no project-specific
       knowledge of — e.g. recommending git format-patch to refresh a
       quilt-managed OpenWrt mac80211 patch.
    
    Add a backport-mode block at the top of the review step that
    detects [X.Y] titles, openwrt-NN.NN base branches, and the
    (cherry picked from commit <sha>) trailer, and narrows the
    inline-issue and nits scope to deviations from main, missing
    prerequisites, and the missing cherry-pick trailer.
    
    Add a paragraph in the inline-issues section telling the bot
    not to prescribe project-specific regeneration commands unless
    the consumer's .github/llm-review-rules.md documents one;
    otherwise describe the desired end-state.

 * CI: gate nightly sub-agent spawn on pre-clone completion
    
    The pre-clone step and the spawn step were adjacent but the
    ordering was implicit. If the model reads step 3 in isolation
    and starts firing Agent calls before step 2's git clones return,
    the sub-agents race the parent and read empty or partial
    ~/extra/<name>-<ref> directories.
    
    Add an explicit gate at the end of step 2 ("Wait for every
    git clone to finish before proceeding to step 3") and a
    matching precondition at the start of step 3 ("Only after
    step 2 has fully completed").