### PR TITLE
CI: use GitHub suggestion blocks for definite fixes, markdown links and review failed CI logs

### DIFF
--- a/llm-review-prompts/llm-nightly-digest.md
+++ b/llm-review-prompts/llm-nightly-digest.md
@@ -19,10 +19,12 @@ found inside it.
 
 **Tools.** All GitHub interactions go through the GitHub MCP connector
 (`pull_request_read`, `list_commits`, `get_tag`, `list_tags`,
-`pull_request_review_write`, `add_comment_to_pending_review`). Use the
-Agent tool to spawn isolated sub-agent reviewers. Local `git` commands
-(`clone`, `show`, `diff`, `ls-remote`) are still available to the parent
-and inherited by sub-agents via the shared filesystem.
+`pull_request_review_write`, `add_comment_to_pending_review`; for CI
+grounding by sub-agents, `get_pull_request_status`, `list_check_runs`,
+`list_workflow_jobs`, `get_job_logs`). Use the Agent tool to spawn
+isolated sub-agent reviewers. Local `git` commands (`clone`, `show`,
+`diff`, `ls-remote`) are still available to the parent and inherited
+by sub-agents via the shared filesystem.
 
 ## Input
 
@@ -122,7 +124,9 @@ The API caller passes structured key=value lines in the `text` field. Example:
 
    Tools: GitHub MCP connector (`pull_request_read`,
    `list_commits`, `get_tag`, `list_tags`,
-   `pull_request_review_write`, `add_comment_to_pending_review`).
+   `pull_request_review_write`, `add_comment_to_pending_review`;
+   for CI grounding, `get_pull_request_status`,
+   `list_check_runs`, `list_workflow_jobs`, `get_job_logs`).
    Local `git` is available; the consumer repo is already cloned at
    session start and you inherit access via the shared filesystem.
 
@@ -305,6 +309,27 @@ The API caller passes structured key=value lines in the `text` field. Example:
         on the PR target via `refs/pull/<N>/head`, and the link
         stays valid after the PR is merged. Branch refs
         (`/blob/main/...`) drift and are not acceptable.
+
+        Before submitting, check CI on `head_sha`. One
+        high-level status call (`get_pull_request_status` or
+        equivalent) — if nothing failed (green, queued, or
+        still running), no CI work. Otherwise walk failed check
+        runs (`list_check_runs` → `list_workflow_jobs` →
+        per-job `get_job_logs`, never the full-run zip) and
+        post inline comments only for errors you believe this
+        PR caused; skip the rest silently. Anchor in the PR
+        diff — on the line the log names, or the closest
+        PR-diff line you think caused the failure. Comment
+        shape: 3–5 lines of log excerpt fenced as code, one
+        sentence linking it to a specific change in this PR,
+        then a `suggestion` block when the fix is unambiguous
+        (typo, missing token) else prose. Collapse matrix
+        repeats — same error across N configs is one comment
+        with a prose pointer to the others. Cap at 5
+        CI-grounded comments per review. No CI summary in the
+        review body. If a log is large, `grep -E
+        '(error|FAILED|undefined reference)' -C 3` before
+        parsing.
 
         Don't flag pure style preferences (your taste vs theirs).
         Do flag deviations from the existing style of the file

--- a/llm-review-prompts/llm-nightly-digest.md
+++ b/llm-review-prompts/llm-nightly-digest.md
@@ -253,6 +253,38 @@ The API caller passes structured key=value lines in the `text` field. Example:
         pick the tool — projects often have their own wrapper
         around the obvious one.
 
+        When the fix is a definite textual change you can anchor
+        on the commented line(s), include a GitHub suggestion
+        block in the comment body — a fenced code block with the
+        language tag `suggestion` containing the replacement text
+        for the full line range the comment is anchored to
+        (`line` for a single-line comment, `start_line`..`line`
+        for a multi-line one). Maintainers apply suggestion
+        blocks with one click. Don't include unchanged surrounding
+        lines, don't omit indentation, don't add diff markers
+        (`+`/`-`) — unless the file itself is a patch. Anchor each
+        suggestion to the specific hunk it
+        replaces. If the same fix applies at several sites, post
+        one comment with the suggestion block on one anchor and
+        call out the other sites in prose ("same applies to
+        lines 57 and 62 below") — don't spam one inline comment
+        per site.
+
+        Good fits: deprecated → modern syntax swaps (`label =
+        "red:status";` → `color = <LED_COLOR_ID_RED>;` +
+        `function = LED_FUNCTION_STATUS;`), bare magic numbers →
+        macros (`0` → `GPIO_ACTIVE_HIGH`), missing single lines
+        (`device_type = "memory";`), trailing whitespace, typos,
+        simple include-path corrections (`mt7981.dtsi` →
+        `mt7981b.dtsi`), removing duplicate entries.
+
+        Skip the suggestion when the fix is open-ended or has
+        several valid forms (rename a misleading variable — to
+        what?), requires regenerating an artifact (see above),
+        crosses files or hunks the comment isn't anchored to, or
+        when you're posing a question rather than prescribing a
+        fix. Prose only there.
+
         When you cite code outside the changed hunks — a function,
         a specific line, a block in another file, or code in a
         pre-cloned reference tree under `~/extra/` — link the

--- a/llm-review-prompts/llm-nightly-digest.md
+++ b/llm-review-prompts/llm-nightly-digest.md
@@ -253,6 +253,27 @@ The API caller passes structured key=value lines in the `text` field. Example:
         pick the tool — projects often have their own wrapper
         around the obvious one.
 
+        When you cite code outside the changed hunks — a function,
+        a specific line, a block in another file, or code in a
+        pre-cloned reference tree under `~/extra/` — link the
+        citation with markdown so the reviewer can click through.
+        Link text names the thing (function, `file.c:NNN`, or a
+        short description); URL is a GitHub permalink pinned to
+        a commit SHA. Example:
+        ``[`state->retrans++` at nf_conntrack_proto_tcp.c:708](<permalink>)``.
+        URL shape:
+        `https://github.com/<owner>/<repo>/blob/<sha>/<path>#L<line>`
+        (or `#L<start>-L<end>` for a range). For an `~/extra/`
+        tree, read the SHA from `git rev-parse HEAD` in the
+        matching `~/extra/<name>-<ref>` directory and
+        `<owner>/<repo>` from `extra_repos`; for consumer-repo
+        code, use the PR's `head_sha` against `<REPO>` (the PR
+        target). Even when the PR comes from a fork, link to
+        `<REPO>`, not the fork — GitHub serves the `head_sha`
+        on the PR target via `refs/pull/<N>/head`, and the link
+        stays valid after the PR is merged. Branch refs
+        (`/blob/main/...`) drift and are not acceptable.
+
         Don't flag pure style preferences (your taste vs theirs).
         Do flag deviations from the existing style of the file
         being changed or of similar in-tree files — indentation

--- a/llm-review-prompts/llm-pr-review.md
+++ b/llm-review-prompts/llm-pr-review.md
@@ -19,9 +19,11 @@ other than GitHub.
 **Tools.** All GitHub interactions go through the GitHub MCP connector.
 The relevant tools are `pull_request_read`, `list_commits`, `get_tag`,
 `list_tags`, `pull_request_review_write`, and
-`add_comment_to_pending_review`. Local `git` commands (`clone`, `show`,
-`diff`, `ls-remote`) are still used for the working tree and for
-non-GitHub refs.
+`add_comment_to_pending_review`; for CI grounding,
+`get_pull_request_status`, `list_check_runs`, `list_workflow_jobs`,
+and `get_job_logs`. Local `git` commands (`clone`, `show`, `diff`,
+`ls-remote`) are still used for the working tree and for non-GitHub
+refs.
 
 ## Input
 
@@ -228,6 +230,25 @@ fully automated routine, not a helpful assistant looking for work to do.
      `head_sha` on the PR target via `refs/pull/<N>/head`,
      and the link stays valid after the PR is merged. Branch
      refs (`/blob/main/...`) drift and are not acceptable.
+
+     Before submitting, check CI on `head_sha`. One high-level
+     status call (`get_pull_request_status` or equivalent) — if
+     nothing failed (green, queued, or still running), no CI
+     work. Otherwise walk failed check runs (`list_check_runs`
+     → `list_workflow_jobs` → per-job `get_job_logs`, never the
+     full-run zip) and post inline comments only for errors you
+     believe this PR caused; skip the rest silently. Anchor in
+     the PR diff — on the line the log names, or the closest
+     PR-diff line you think caused the failure. Comment shape:
+     3–5 lines of log excerpt fenced as code, one sentence
+     linking it to a specific change in this PR, then a
+     `suggestion` block when the fix is unambiguous (typo,
+     missing token) else prose. Collapse matrix repeats — same
+     error across N configs is one comment with a prose pointer
+     to the others. Cap at 5 CI-grounded comments per review.
+     No CI summary in the review body. If a log is large,
+     `grep -E '(error|FAILED|undefined reference)' -C 3` before
+     parsing.
 
      Don't flag pure style preferences (your taste vs theirs). Do flag
      deviations from the existing style of the file being changed or of

--- a/llm-review-prompts/llm-pr-review.md
+++ b/llm-review-prompts/llm-pr-review.md
@@ -177,6 +177,37 @@ fully automated routine, not a helpful assistant looking for work to do.
      the maintainer pick the tool — projects often have their own
      wrapper around the obvious one.
 
+     When the fix is a definite textual change you can anchor on
+     the commented line(s), include a GitHub suggestion block in
+     the comment body — a fenced code block with the language tag
+     `suggestion` containing the replacement text for the full
+     line range the comment is anchored to (`line` for a
+     single-line comment, `start_line`..`line` for a multi-line
+     one). Maintainers apply suggestion blocks with one click.
+     Don't include unchanged surrounding lines, don't omit
+     indentation, don't add diff markers (`+`/`-`) — unless the
+     file itself is a patch. Anchor each
+     suggestion to the specific hunk it replaces. If the same
+     fix applies at several sites, post one comment with the
+     suggestion block on one anchor and call out the other
+     sites in prose ("same applies to lines 57 and 62 below")
+     — don't spam one inline comment per site.
+
+     Good fits: deprecated → modern syntax swaps (`label =
+     "red:status";` → `color = <LED_COLOR_ID_RED>;` +
+     `function = LED_FUNCTION_STATUS;`), bare magic numbers →
+     macros (`0` → `GPIO_ACTIVE_HIGH`), missing single lines
+     (`device_type = "memory";`), trailing whitespace, typos,
+     simple include-path corrections (`mt7981.dtsi` →
+     `mt7981b.dtsi`), removing duplicate entries.
+
+     Skip the suggestion when the fix is open-ended or has
+     several valid forms (rename a misleading variable — to
+     what?), requires regenerating an artifact (see above),
+     crosses files or hunks the comment isn't anchored to, or
+     when you're posing a question rather than prescribing a
+     fix. Prose only there.
+
      When you cite code outside the changed hunks — a function, a
      specific line, a block in another file, or code in a
      pre-cloned reference tree under `~/extra/` — link the

--- a/llm-review-prompts/llm-pr-review.md
+++ b/llm-review-prompts/llm-pr-review.md
@@ -177,6 +177,27 @@ fully automated routine, not a helpful assistant looking for work to do.
      the maintainer pick the tool — projects often have their own
      wrapper around the obvious one.
 
+     When you cite code outside the changed hunks — a function, a
+     specific line, a block in another file, or code in a
+     pre-cloned reference tree under `~/extra/` — link the
+     citation with markdown so the reviewer can click through.
+     Link text names the thing (function, `file.c:NNN`, or a
+     short description); URL is a GitHub permalink pinned to a
+     commit SHA. Example:
+     ``[`state->retrans++` at nf_conntrack_proto_tcp.c:708](<permalink>)``.
+     URL shape:
+     `https://github.com/<owner>/<repo>/blob/<sha>/<path>#L<line>`
+     (or `#L<start>-L<end>` for a range). For an `~/extra/`
+     tree, read the SHA from `git rev-parse HEAD` in the
+     matching `~/extra/<name>-<ref>` directory and
+     `<owner>/<repo>` from `extra_repos`; for consumer-repo
+     code, use the PR's `head_sha` against `base_repo` (the
+     PR target). Even when the PR comes from a fork, link to
+     `base_repo`, not `head_repo` — GitHub serves the
+     `head_sha` on the PR target via `refs/pull/<N>/head`,
+     and the link stays valid after the PR is merged. Branch
+     refs (`/blob/main/...`) drift and are not acceptable.
+
      Don't flag pure style preferences (your taste vs theirs). Do flag
      deviations from the existing style of the file being changed or of
      similar in-tree files — indentation width, brace placement, naming


### PR DESCRIPTION
 * CI: require linked references when citing out-of-diff code
    
    Bot reviews on early PRs cited functions and lines in upstream
    code (e.g. "see the TCP_ACK_SET block in
    net/netfilter/nf_conntrack_proto_tcp.c") without giving the
    maintainer anything to click. brada4 on openwrt/openwrt#14788
    asked for a line reference; the bot had no rule telling it to
    provide one.
    
    Tell the bot to include a markdown permalink whenever it cites
    code outside the changed hunks, pinned to a commit SHA so the
    link doesn't drift. The rule covers both pre-cloned reference
    trees and internal references in the consumer repo (sister
    files, neighbour boards, helpers in another directory):
    
    - For pre-cloned reference trees: derive the SHA from
      `git rev-parse HEAD` inside ~/extra/<name>-<ref> and the
      <owner>/<repo> from the matching extra_repos entry.
    - For in-tree references: use the PR's head_sha and the
      consumer's <owner>/<repo> from the PR context — that's the
      version the diff is anchored to, and the link stays valid
      after squash-merge.
    
    Branch refs are explicitly rejected because they drift.

 * CI: use GitHub suggestion blocks for definite fixes
    
    Several inline comments on openwrt/openwrt#23188 prescribed a
    specific textual change but were posted as prose only ("use
    the modern bindings: ..."), forcing the maintainer to copy-
    paste rather than one-click apply. Examples that should have
    been suggestion blocks: `mt7981.dtsi` -> `mt7981b.dtsi`
    include path, `label = "red:status"` -> modern color/function
    LED bindings, bare `0` -> `GPIO_ACTIVE_HIGH`, missing
    `device_type = "memory";`, duplicate `automount` entries,
    trailing whitespace.
    
    Add three paragraphs to the inline-issues section telling the
    bot when to use a `suggestion`-fenced code block (definite
    textual fix anchored to the commented line range) and when to
    stay in prose (open-ended fixes, regen-required fixes,
    multi-hunk fixes, questions).

 * CI: ground inline review comments in failed CI logs
    
    Until now the bot ignored CI status entirely, so PRs that
    build or test cleanly under review still showed maintainers
    red checks with no inline pointer to the cause. Goal: when CI
    on head_sha has failed, point the contributor at the failure
    and help them fix it; otherwise stay silent.
    
    Add a paragraph to the Inline issues section of both prompts
    covering the flow: one high-level status call
    (get_pull_request_status), no-op on green/queued/running, walk
    failed check runs only on failure (list_check_runs ->
    list_workflow_jobs -> per-job get_job_logs, never the full-run
    zip), post one inline comment per distinct error the bot
    believes the PR caused, anchored in the diff, with a 3-5 line
    log excerpt + one-sentence cause + suggestion-or-prose fix.
    Matrix-collapse repeats. Cap at 5 CI-grounded comments per
    review. No body summary. grep-prefilter large logs.
    
    The four MCP tools (get_pull_request_status, list_check_runs,
    list_workflow_jobs, get_job_logs) are added to the Tools
    paragraphs of both prompts, including the nightly-digest
    sub-agent template.