### PR TITLE
multi-arch-test-build: more fixes and improvements

### DIFF
--- a/.github/scripts/test_entrypoint.sh
+++ b/.github/scripts/test_entrypoint.sh
@@ -10,6 +10,7 @@ mkdir -p /var/lock/
 mkdir -p /var/log/
 
 CI_HELPERS="${CI_HELPERS:-/scripts/ci_helpers.sh}"
+TEST_PACKAGES="binutils coreutils-timeout file"
 
 source "$CI_HELPERS"
 
@@ -245,11 +246,11 @@ if is_opkg; then
 	# This fixes running CI tests.
 	sed -i '/check_signature/d' /etc/opkg.conf
 	opkg update
-	opkg install binutils coreutils-timeout file
+	opkg install $TEST_PACKAGES
 elif is_apk; then
 	echo "/ci/packages.adb" >> /etc/apk/repositories.d/distfeeds.list
 	apk update
-	apk add binutils coreutils-timeout file
+	apk add $TEST_PACKAGES
 fi
 
 if generic_tests_enabled && generic_tests_forced; then
@@ -335,6 +336,11 @@ for PKG in /ci/*.[ai]pk; do
 			err 'Test failed'
 			RET=1
 		fi
+	fi
+
+	# Don't remove test packages
+	if [[ " ${TEST_PACKAGES} " =~ " ${PKG_NAME} " ]]; then
+		continue
 	fi
 
 	if is_opkg; then

--- a/.github/scripts/test_entrypoint.sh
+++ b/.github/scripts/test_entrypoint.sh
@@ -66,22 +66,35 @@ check_exec() {
 		return 0
 	fi
 
-	local found_version=0
-
-	for flag in --version -version version -v -V --help -help -?; do
-		if timeout 3s "$file" "$flag" 2>&1 | grep -F "$PKG_VERSION"; then
-			status_pass "Version check ($file)"
-			found_version=1
-			break
+	# Some executables behave differently depending on the filename, so if an
+	# alternative link is present, try that first.
+	# NB: Busybox doesn't support arrays
+	local files_to_check=''
+	local link_target
+	while IFS= read -r -d '' link; do
+		link_target=$(readlink -f "$link")
+		if [ "$link_target" = "$file" ]; then
+			files_to_check="$files_to_check $link"
 		fi
+	done < <(find /usr/bin -type l -print0 2>/dev/null)
+
+	# Check the actual file last
+	files_to_check="$files_to_check $file"
+
+	local output
+	for check_file in $files_to_check; do
+		for flag in --version -version version -v -V --help -help -?; do
+			output=$(timeout --kill-after=5s 10s "$check_file" "$flag" 2>&1) || continue
+
+			if echo "$output" | grep -F "$PKG_VERSION"; then
+				status_pass "Version check ($check_file)"
+				return 0
+			fi
+		done
 	done
 
-	if [ "$found_version" = 0 ]; then
-		status_warn "Version check ($file)"
-		return 2
-	fi
-
-	return 0
+	status_warn "Version check ($file)"
+	return 2
 }
 
 check_linked_libs() {

--- a/.github/scripts/test_entrypoint.sh
+++ b/.github/scripts/test_entrypoint.sh
@@ -113,7 +113,7 @@ check_linked_libs() {
 
 check_lib()	{
 	local file="$1"
-	local has_failure=0
+
 	local soname
 	soname=$(readelf -d "$file" 2>/dev/null | grep 'SONAME' | sed -E 's/.*\[(.*)\].*/\1/')
 	if [ -n "$soname" ]; then
@@ -129,19 +129,15 @@ check_lib()	{
 		lib_dir=$(dirname "$file")
 		if [ "$(basename "$file")" != "$soname" ] && [ ! -L "$lib_dir/$soname" ]; then
 			status_fail "Library $file has SONAME '$soname' but no corresponding symlink was found in $lib_dir"
-			has_failure=1
+			return 1
 		elif [ "$(readlink -f "$lib_dir/$soname")" != "$(readlink -f "$file")" ]; then
 			status_fail "Symlink for SONAME '$soname' does not point to $file"
-			has_failure=1
+			return 1
 		else
 			status_pass "SONAME link for $file is correct"
 		fi
 	else
 		status_warn "Library $file doesn't have a SONAME"
-	fi
-
-	if [ "$has_failure" = 1 ]; then
-		return 1
 	fi
 
 	return 0

--- a/.github/scripts/test_entrypoint.sh
+++ b/.github/scripts/test_entrypoint.sh
@@ -245,11 +245,11 @@ if is_opkg; then
 	# This fixes running CI tests.
 	sed -i '/check_signature/d' /etc/opkg.conf
 	opkg update
-	opkg install binutils file
+	opkg install binutils coreutils-timeout file
 elif is_apk; then
 	echo "/ci/packages.adb" >> /etc/apk/repositories.d/distfeeds.list
 	apk update
-	apk add binutils file
+	apk add binutils coreutils-timeout file
 fi
 
 if generic_tests_enabled && generic_tests_forced; then


### PR DESCRIPTION
Some executables behave differently depending on the filename, so if an alternative link is present, try that first.

Increase version check timeout to 10s, and kill stubborn processes after 5 more seconds.

Store result of the timeout and command in a variable to prevent any
buffering issues.

Simplify executable version check to exit early.

Install the missing `coreutils-timeout` used for testing.

Don't remove test packages that are used for testing, e.g. `file`.

This will still require version check overrides for packages that don't report any version via executables, e.g. sctp-tools, coreutils-test, coreutils-false, etc.

Fixes: b735416 ("multi-arch-test-build: add generic package tests")
Fixes: 241ae82 ("multi-arch-test-build: timeout generic version checks")

Example run:
- https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/25556961342/job/75018339721?pr=25#step:17:4383