### PR TITLE
multi-arch-test-build: install coreutils-timeout in test container

### DIFF
--- a/.github/scripts/test_entrypoint.sh
+++ b/.github/scripts/test_entrypoint.sh
@@ -245,11 +245,13 @@ if is_opkg; then
 	# This fixes running CI tests.
 	sed -i '/check_signature/d' /etc/opkg.conf
 	opkg update
-	opkg install binutils file
+	# coreutils-timeout is needed because BusyBox is built without the
+	# timeout applet (BUSYBOX_DEFAULT_TIMEOUT=n) in the openwrt/rootfs image.
+	opkg install binutils file coreutils-timeout
 elif is_apk; then
 	echo "/ci/packages.adb" >> /etc/apk/repositories.d/distfeeds.list
 	apk update
-	apk add binutils file
+	apk add binutils file coreutils-timeout
 fi
 
 if generic_tests_enabled && generic_tests_forced; then


### PR DESCRIPTION
## Problem

After commit 241ae82 ("multi-arch-test-build: timeout generic version checks") landed, the `Test via Docker container` step fails for **every** package shipping a binary in `/bin/`, `/sbin/`, `/usr/bin/`, `/usr/libexec/` or `/usr/sbin/` with:

```
No executables in the package provided version <version>
```

## Root cause

That commit wrapped each version probe in `check_exec()` with `timeout 3s ...`:

```sh
if timeout 3s "$file" "$flag" 2>&1 | grep -F "$PKG_VERSION"; then
```

But the test container is built `FROM openwrt/rootfs:$ARCH` whose only userland is BusyBox, and OpenWrt's BusyBox is built without the `timeout` applet — `BUSYBOX_DEFAULT_TIMEOUT` is `default n` in `package/utils/busybox/Config-defaults.in`. The script only `opkg install`s `binutils file`, so no GNU `timeout` is pulled in either.

Trace through what happens for every binary, for every probe flag:

1. The shell can't find `timeout` → "timeout: not found" on stderr.
2. `pipefail` is not set, so the pipeline status is `grep`'s. With nothing matching `$PKG_VERSION` on stdin, `grep` exits 1.
3. The `if` falls through, the loop tries the next flag, same result.
4. `found_version` stays 0, `check_exec` returns 2, `version_missing` is incremented.
5. Once every binary has been "checked", `exec_checked == version_missing` and the script aborts with the error above.

The actual binary is never executed, so the version test never has a chance to pass.

## Fix

Install `coreutils-timeout` alongside `binutils` and `file` so `/usr/bin/timeout` from GNU coreutils is available. It accepts the same `3s` duration syntax the script uses, so no other change is needed.

`coreutils-timeout` is already part of the standard OpenWrt `packages` feed and is therefore reachable from the rootfs container's default `opkg`/`apk` repositories.

Fixes: 241ae82 ("multi-arch-test-build: timeout generic version checks")