### PR TITLE
multi-arch-test-build: grep version output even on non-zero exit

### DIFF
--- a/.github/scripts/test_entrypoint.sh
+++ b/.github/scripts/test_entrypoint.sh
@@ -84,7 +84,7 @@ check_exec() {
 	local output
 	for check_file in $files_to_check; do
 		for flag in --version -version version -v -V --help -help -?; do
-			output=$(timeout --kill-after=5s 10s "$check_file" "$flag" 2>&1) || continue
+			output=$(timeout --kill-after=5s 10s "$check_file" "$flag" 2>&1) || true
 
 			if echo "$output" | grep -F "$PKG_VERSION"; then
 				status_pass "Version check ($check_file)"


### PR DESCRIPTION
The version probe in `check_exec()` runs each candidate flag through:

```sh
output=$(timeout --kill-after=5s 10s "$check_file" "$flag" 2>&1) || continue

if echo "$output" | grep -F "$PKG_VERSION"; then
    status_pass "Version check ($check_file)"
    return 0
fi
```

The `2>&1` is there precisely so the help/usage blob a tool dumps when given an unrecognized flag — which often contains the version — gets captured and grepped. But the `|| continue` throws that captured output away whenever the command exits non-zero, so the grep never gets to see it.

`unbound-host` is a clean example. It has no flag in the probe list that exits 0:

```
root@BPI-R4:~# unbound-host --version
unbound-host: unrecognized option: -
Usage:    unbound-host [-C configfile] [-vdhr46] [-c class] [-t type]
                     [-y key] [-f keyfile] [-F namedkeyfile] hostname
  Queries the DNS for information.
  ...
Version 1.24.2
BSD licensed, see LICENSE in source package for details.
Report bugs to unbound-bugs@nlnetlabs.nl or https://github.com/NLnetLabs/unbound/issues
```

`Version 1.24.2` matches `$PKG_VERSION` exactly and is sitting in the captured `$output`, but the non-zero exit means `|| continue` fires before grep runs. Every flag in the loop hits the same fate — even `-h`, which `unbound-host` treats identically to any other "unknown" option and exits non-zero on. The result is a spurious:

```
unbound-host: [warn] Version check (/usr/sbin/unbound-host)
unbound-host: No executables in the package provided version 1.24.2
unbound-host: Generic tests failed
```

The fix: switch the errexit-suppressor to `|| true` so the grep below decides whether the version was found, instead of pre-filtering on exit status. `set -o errexit` (line 6) is still satisfied; `set -o pipefail` is explicitly off, so the subsequent `if echo … | grep …` is unaffected.