### PR TITLE
CI: support manual workflow_dispatch to refresh ccache

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -54,7 +54,7 @@ jobs:
           TARGETS="$(echo "$ALL_TARGETS" | sort -u -t '/' -k1,1 | cut -d " " -f 1)"
 
           # On testing non-specific target, skip testing each subtarget if we are testing pr
-          if [ ${{ github.event_name }} != 'push' ]; then
+          if [ ${{ github.event_name }} != 'push' ] && [ ${{ github.event_name }} != 'workflow_dispatch' ]; then
             if echo "$CHANGED_FILES" | grep -v -q -P ^target/linux/.*/ ||
               echo "$CHANGED_FILES" | grep -q target/linux/generic; then
               TARGETS_SUBTARGETS=$TARGETS
@@ -70,13 +70,17 @@ jobs:
             TARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 1)
             SUBTARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 2)
 
-            if echo "$CHANGED_FILES" | grep -q target/linux/generic ||
+            # On manual dispatch: build every target/subtarget with both kernel versions, ignoring changed files
+            if [ ${{ github.event_name }} = 'workflow_dispatch' ] ||
+              echo "$CHANGED_FILES" | grep -q target/linux/generic ||
               echo "$CHANGED_FILES" | grep -q "package/kernel" ||
               echo "$CHANGED_FILES" | grep -q "target/linux/$TARGET"; then
 
               # test target if kernel version is affected
               # If AFFECTED_KERNEL_VERSIONS is empty fallback to simple testing (case of changed files)
-              if [ -z "${{ env.AFFECTED_KERNEL_VERSIONS }}" ] || echo "${{ env.AFFECTED_KERNEL_VERSIONS }}" | grep -q "$TARGET_KERNEL_VER"; then
+              if [ ${{ github.event_name }} = 'workflow_dispatch' ] ||
+                [ -z "${{ env.AFFECTED_KERNEL_VERSIONS }}" ] ||
+                echo "${{ env.AFFECTED_KERNEL_VERSIONS }}" | grep -q "$TARGET_KERNEL_VER"; then
                 TUPLE='{"target":"'"$TARGET"'","subtarget":"'"$SUBTARGET"'"}'
                 [[ $FIRST -ne 1 ]] && JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS"','
                 JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS""$TUPLE"
@@ -84,7 +88,9 @@ jobs:
               fi
 
               # Also test testing kernel version if kernel version is affected
-              if [ -n "$TARGET_TESTING_KERNEL_VER" ] && echo "${{ env.AFFECTED_KERNEL_VERSIONS }}" | grep -q "$TARGET_TESTING_KERNEL_VER"; then
+              if [ -n "$TARGET_TESTING_KERNEL_VER" ] &&
+                ( [ ${{ github.event_name }} = 'workflow_dispatch' ] ||
+                  echo "${{ env.AFFECTED_KERNEL_VERSIONS }}" | grep -q "$TARGET_TESTING_KERNEL_VER" ); then
                 TUPLE='{"target":"'"$TARGET"'","subtarget":"'"$SUBTARGET"'","testing":"'"$TARGET_TESTING_KERNEL_VER"'"}'
                 [[ $FIRST -ne 1 ]] && JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS"','
                 JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS""$TUPLE"
@@ -103,13 +109,16 @@ jobs:
             TARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 1)
             SUBTARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 2)
 
-            if echo "$CHANGED_FILES" | grep -q target/linux/generic ||
+            if [ ${{ github.event_name }} = 'workflow_dispatch' ] ||
+              echo "$CHANGED_FILES" | grep -q target/linux/generic ||
               echo "$CHANGED_FILES" | grep -q "package/kernel" ||
               echo "$CHANGED_FILES" | grep -q "target/linux/$TARGET"; then
 
               # test target if kernel version is affected
               # If AFFECTED_KERNEL_VERSIONS is empty fallback to simple testing (case of changed files)
-              if [ -z "${{ env.AFFECTED_KERNEL_VERSIONS }}" ] || echo "${{ env.AFFECTED_KERNEL_VERSIONS }}" | grep -q "$TARGET_KERNEL_VER"; then
+              if [ ${{ github.event_name }} = 'workflow_dispatch' ] ||
+                [ -z "${{ env.AFFECTED_KERNEL_VERSIONS }}" ] ||
+                echo "${{ env.AFFECTED_KERNEL_VERSIONS }}" | grep -q "$TARGET_KERNEL_VER"; then
                 TUPLE='{"target":"'"$TARGET"'","subtarget":"'"$SUBTARGET"'"}'
                 [[ $FIRST -ne 1 ]] && JSON_TARGETS="$JSON_TARGETS"','
                 JSON_TARGETS="$JSON_TARGETS""$TUPLE"
@@ -117,7 +126,9 @@ jobs:
               fi
 
               # Also test testing kernel version if kernel version is affected
-              if [ -n "$TARGET_TESTING_KERNEL_VER" ] && echo "${{ env.AFFECTED_KERNEL_VERSIONS }}" | grep -q "$TARGET_TESTING_KERNEL_VER"; then
+              if [ -n "$TARGET_TESTING_KERNEL_VER" ] &&
+                ( [ ${{ github.event_name }} = 'workflow_dispatch' ] ||
+                  echo "${{ env.AFFECTED_KERNEL_VERSIONS }}" | grep -q "$TARGET_TESTING_KERNEL_VER" ); then
                 TUPLE='{"target":"'"$TARGET"'","subtarget":"'"$SUBTARGET"'","testing":"'"$TARGET_TESTING_KERNEL_VER"'"}'
                 [[ $FIRST -ne 1 ]] && JSON_TARGETS="$JSON_TARGETS"','
                 JSON_TARGETS="$JSON_TARGETS""$TUPLE"
@@ -185,7 +196,7 @@ jobs:
       testing: ${{ matrix.testing != '' }}
 
   upload-ccache-cache-in-s3:
-    if: github.event_name == 'push' && github.repository_owner == 'openwrt'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'openwrt'
     name: Upload ccache cache to s3
     needs: [determine_targets, build]
     strategy:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -49,7 +49,7 @@ jobs:
       check_packages_list: ${{ needs.determine_changed_packages.outputs.changed_packages }}
 
   upload-ccache-cache-in-s3:
-    if: github.event_name == 'push' && github.repository_owner == 'openwrt'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'openwrt'
     name: Upload ccache cache to s3
     needs: build
     strategy:

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -169,7 +169,7 @@ jobs:
   check:
     name: Check packages for ${{ inputs.target }}/${{ inputs.subtarget }}
     needs: setup_build
-    if: inputs.check == true && ( github.event_name == 'push' || inputs.check_packages_list != '' )
+    if: inputs.check == true && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' || inputs.check_packages_list != '' )
     runs-on: ubuntu-latest
 
     container: ghcr.io/${{ needs.setup_build.outputs.container }}
@@ -403,7 +403,7 @@ jobs:
       - name: Download and extract ccache cache from s3
         id: restore-ccache-cache-s3
         if: inputs.use_ccache_cache == true &&
-            ( inputs.ccache_type != 'kernel' || inputs.upload_ccache_cache != true || github.event_name != 'push')
+            ( inputs.ccache_type != 'kernel' || inputs.upload_ccache_cache != true || (github.event_name != 'push' && github.event_name != 'workflow_dispatch'))
         working-directory: openwrt
         run: |
           S3_LINK=https://s3-ccache.openwrt-ci.ansuel.com
@@ -439,7 +439,7 @@ jobs:
       - name: Restore ccache cache
         id: restore-ccache-cache
         if: inputs.use_ccache_cache == true &&
-            ( inputs.ccache_type != 'kernel' || inputs.upload_ccache_cache != true || github.event_name != 'push') &&
+            ( inputs.ccache_type != 'kernel' || inputs.upload_ccache_cache != true || (github.event_name != 'push' && github.event_name != 'workflow_dispatch')) &&
             steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
         uses: actions/cache/restore@v5
         with:
@@ -796,7 +796,7 @@ jobs:
           path: "openwrt/logs"
 
       - name: Cleanup ccache
-        if: inputs.use_ccache_cache == true && github.event_name == 'push'
+        if: inputs.use_ccache_cache == true && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
         run: |
@@ -805,12 +805,12 @@ jobs:
 
       - name: Cleanup dl/build_dir/staging_dir to make some space
         working-directory: openwrt
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: rm -rf dl build_dir staging_dir
 
       - name: Delete already present ccache cache
         if: steps.restore-ccache-cache.outputs.cache-hit == 'true' && inputs.use_ccache_cache == true  &&
-          github.event_name == 'push' && steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
         uses: octokit/request-action@v3.x
         with:
           route: DELETE /repos/{repository}/actions/caches?key={key}
@@ -820,7 +820,7 @@ jobs:
           INPUT_KEY: ${{ steps.restore-ccache-cache.outputs.cache-primary-key }}
 
       - name: Save ccache cache
-        if: inputs.use_ccache_cache == true && github.event_name == 'push' &&
+        if: inputs.use_ccache_cache == true && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
           steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
@@ -828,14 +828,14 @@ jobs:
           key: ${{ steps.restore-ccache-cache.outputs.cache-primary-key }}
 
       - name: Archive ccache
-        if: inputs.use_ccache_cache == true  && github.event_name == 'push' &&
+        if: inputs.use_ccache_cache == true  && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
           inputs.upload_ccache_cache == true
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
         run: tar --exclude='.ccache/tmp' -cf ${{ needs.setup_build.outputs.ccache_name }}.tar .ccache
 
       - name: Upload ccache cache
-        if: inputs.use_ccache_cache == true && github.event_name == 'push' &&
+        if: inputs.use_ccache_cache == true && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
           inputs.upload_ccache_cache == true
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Push runs of Build Kernel / Build all core packages on main can be displaced from the concurrency queue by the next push, so the s3 ccache for the displaced commits is never refreshed. Add a manual escape hatch: when the consumer triggers via workflow_dispatch, run the build like a push and upload the ccache.

In kernel.yml's Set targets step, treat workflow_dispatch like push for the subtarget-skip logic, and short-circuit the changed-files filter so every target/subtarget plus its testing kernel ends up in the matrix. The full per-commit cache is produced regardless of which paths the dispatched ref happens to touch.

In packages.yml, only broaden the ccache upload gate; the build matrix stays at malta/be + x86/64 with the default kernel.

reusable_build.yml: each existing github.event_name == 'push' guard (check job, ccache restore-from-s3 / restore-from-cache, cleanup, save, archive, upload, plus the Delete already present ccache cache step that frees the cache key before save) now also matches workflow_dispatch.

OpenWrt PR: https://github.com/openwrt/openwrt/pull/23283