### PR TITLE
ci: propagate secrets and fix validation in S3 reusable workflows

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -168,6 +168,7 @@ jobs:
        matrix:
          include: ${{fromJson(needs.determine_targets.outputs.targets_subtargets)}}
     uses: ./.github/workflows/reusable_build.yml
+    secrets: inherit
     with:
       container_name: toolchain
       target: ${{ matrix.target }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -36,6 +36,7 @@ jobs:
           - target: x86
             subtarget: 64
     uses: ./.github/workflows/reusable_build.yml
+    secrets: inherit
     with:
       container_name: toolchain
       target: ${{ matrix.target }}

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
     secrets:
       coverity_api_token:
+      ccache_s3_endpoint:
+      ccache_s3_bucket:
+      ccache_s3_public_url:
     outputs:
       ccache_tag:
         value: ${{ jobs.setup_build.outputs.ccache_tag }}
@@ -272,6 +275,9 @@ jobs:
     needs: setup_build
     runs-on: ubuntu-latest
 
+    env:
+      CCACHE_S3_ENDPOINT: ${{ secrets.ccache_s3_endpoint }}
+
     container:
       image: ghcr.io/${{ needs.setup_build.outputs.container }}
       options: --privileged --pid=host
@@ -400,13 +406,21 @@ jobs:
 
           echo "LLVM_FILE=$LLVM_FILE" >> "$GITHUB_ENV"
 
-      - name: Download and extract ccache cache from s3
+      - name: Download and extract ccache cache from S3
         id: restore-ccache-cache-s3
-        if: inputs.use_ccache_cache == true &&
-            ( inputs.ccache_type != 'kernel' || inputs.upload_ccache_cache != true || (github.event_name != 'push' && github.event_name != 'workflow_dispatch'))
+        if: |
+          inputs.use_ccache_cache == true &&
+          ( inputs.ccache_type != 'kernel' || (inputs.upload_ccache_cache != true && env.CCACHE_S3_ENDPOINT == '') || (github.event_name != 'push' && github.event_name != 'workflow_dispatch'))
         working-directory: openwrt
         run: |
-          S3_LINK=https://s3-ccache.openwrt-ci.ansuel.com
+          if [ -n "${{ secrets.ccache_s3_public_url }}" ]; then
+            S3_LINK="${{ secrets.ccache_s3_public_url }}"
+          elif [ -n "${{ secrets.ccache_s3_endpoint }}" ] && [ -n "${{ secrets.ccache_s3_bucket }}" ]; then
+            S3_LINK="${{ secrets.ccache_s3_endpoint }}/${{ secrets.ccache_s3_bucket }}"
+          else
+            S3_LINK="https://s3-ccache.openwrt-ci.ansuel.com"
+          fi
+          
           CCACHE_TAR=${{ needs.setup_build.outputs.ccache_name }}.tar
 
           if curl -o /dev/null -s --head --fail $S3_LINK/$CCACHE_TAR; then
@@ -438,9 +452,10 @@ jobs:
 
       - name: Restore ccache cache
         id: restore-ccache-cache
-        if: inputs.use_ccache_cache == true &&
-            ( inputs.ccache_type != 'kernel' || inputs.upload_ccache_cache != true || (github.event_name != 'push' && github.event_name != 'workflow_dispatch')) &&
-            steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
+        if: |
+          inputs.use_ccache_cache == true &&
+          ( inputs.ccache_type != 'kernel' || (inputs.upload_ccache_cache != true && env.CCACHE_S3_ENDPOINT == '') || (github.event_name != 'push' && github.event_name != 'workflow_dispatch')) &&
+          steps.restore-ccache-cache-s3.outputs.cache-hit != 'true'
         uses: actions/cache/restore@v5
         with:
           path: openwrt/.ccache
@@ -828,15 +843,17 @@ jobs:
           key: ${{ steps.restore-ccache-cache.outputs.cache-primary-key }}
 
       - name: Archive ccache
-        if: inputs.use_ccache_cache == true  && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          inputs.upload_ccache_cache == true
+        if: |
+          inputs.use_ccache_cache == true && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+          (inputs.upload_ccache_cache == true || env.CCACHE_S3_ENDPOINT != '')
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
         run: tar --exclude='.ccache/tmp' -cf ${{ needs.setup_build.outputs.ccache_name }}.tar .ccache
 
       - name: Upload ccache cache
-        if: inputs.use_ccache_cache == true && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          inputs.upload_ccache_cache == true
+        if: |
+          inputs.use_ccache_cache == true && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+          (inputs.upload_ccache_cache == true || env.CCACHE_S3_ENDPOINT != '')
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.target }}-${{ inputs.subtarget }}${{ inputs.testing == true && '-testing' || '' }}-ccache-cache

--- a/.github/workflows/reusable_upload-file-s3.yml
+++ b/.github/workflows/reusable_upload-file-s3.yml
@@ -19,9 +19,15 @@ jobs:
   upload-file-in-s3:
     name: Upload file in S3
     runs-on: ubuntu-latest
+    env:
+      S3_ENDPOINT: ${{ secrets.s3_endpoint }}
+      S3_ACCESS_KEY: ${{ secrets.s3_access_key }}
+      S3_SECRET_KEY: ${{ secrets.s3_secret_key }}
+      S3_BUCKET: ${{ secrets.s3_bucket }}
 
     steps:
       - name: Install minio
+        if: env.S3_ENDPOINT != '' && env.S3_ACCESS_KEY != '' && env.S3_SECRET_KEY != '' && env.S3_BUCKET != ''
         run: |
           curl --fail --silent --show-error --location https://dl.min.io/client/mc/release/linux-amd64/mc \
             --create-dirs \
@@ -31,12 +37,15 @@ jobs:
           echo $GITHUB_WORKSPACE/minio-binaries/ >> $GITHUB_PATH
 
       - name: Setup minio
+        if: env.S3_ENDPOINT != '' && env.S3_ACCESS_KEY != '' && env.S3_SECRET_KEY != '' && env.S3_BUCKET != ''
         run: mc alias set s3 ${{ secrets.s3_endpoint }} ${{ secrets.s3_access_key }} ${{ secrets.s3_secret_key }}
 
       - name: Download file
+        if: env.S3_ENDPOINT != '' && env.S3_ACCESS_KEY != '' && env.S3_SECRET_KEY != '' && env.S3_BUCKET != ''
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.download_id }}
 
       - name: Upload file to s3
+        if: env.S3_ENDPOINT != '' && env.S3_ACCESS_KEY != '' && env.S3_SECRET_KEY != '' && env.S3_BUCKET != ''
         run: mc cp ${{ inputs.filename }} s3/${{ secrets.s3_bucket }}/


### PR DESCRIPTION
- Added 'secrets: inherit' to reusable build workflows in kernel.yml and packages.yml to seamlessly propagate S3 credentials.
- Fixed reusable workflow validation errors by using env context instead of secrets context in step 'if' conditionals.
- Enhanced S3 support in reusable_build.yml with custom endpoints and public URLs.
- Added conditional checks in reusable_upload-file-s3.yml to skip S3 tasks if credentials are not set.