### PR TITLE
ci: skip strip and build path checks for eBPF objects

### DIFF
--- a/.github/scripts/test_entrypoint.sh
+++ b/.github/scripts/test_entrypoint.sh
@@ -212,6 +212,11 @@ do_generic_tests() {
 			continue
 		fi
 
+		if file "$file" | grep -q "eBPF"; then
+			status_pass "Binary $file is eBPF object (not stripped and hardcoded paths are allowed)"
+			continue
+		fi
+
 		check_hardcoded_paths "$file"
 
 		if file "$file" | grep 'not stripped'; then


### PR DESCRIPTION
eBPF relocatable ELF objects (like /lib/bpf/*.o) contain debug details (including build paths) needed for loading/BTF association, and should not be stripped to avoid breaking them.

cc: @GeorgeSapkin 