### PR TITLE
llm-nightly-digest: fix stale dedup on heavily-reviewed PRs

### DIFF
--- a/.github/workflows/reusable_llm-nightly-digest.yml
+++ b/.github/workflows/reusable_llm-nightly-digest.yml
@@ -62,8 +62,17 @@ jobs:
             [ -z "$entry" ] && continue
             num="${entry%%$'\t'*}"
             head="${entry##*$'\t'}"
-            last_sha=$(gh api "repos/$REPO/pulls/$num/reviews" \
-              --jq "[.[] | select(.user.login == \"$BOT_USER\")] | last | .commit_id // empty")
+            # Reviews come back oldest-first with no sort option, so read only
+            # the LAST page -- the bot's most recent review lives there. With 10
+            # per page this also re-reviews a PR once roughly 10 reviews/comments
+            # land after the bot's last one: that review drops off the last page,
+            # last_sha stops matching head, and the PR is queued again.
+            reviews="repos/$REPO/pulls/$num/reviews"
+            last_page=$(gh api -i "$reviews?per_page=10" \
+              | grep -i '^link:' | grep -o 'page=[0-9]*>; rel="last"' \
+              | grep -o '[0-9]\+' || true)
+            last_sha=$(gh api "$reviews?per_page=10&page=${last_page:-1}" \
+              --jq ".[] | select(.user.login == \"$BOT_USER\") | .commit_id" | tail -n1)
             if [ "$last_sha" != "$head" ]; then
               needs_review+=("$num")
               if [ ${#needs_review[@]} -ge "$MAX_PRS" ]; then break; fi


### PR DESCRIPTION
The "already reviewed?" gate fetched a PR's reviews without pagination. The reviews API returns results oldest-first, 30 per page, with no sort option, so on PRs with more than 30 reviews the query only saw the oldest page. "| last" then picked an ancient bot review whose commit_id never matches the current head, so the PR was flagged as needing review on every run and re-reviewed twice a day forever (e.g. openwrt/openwrt PR #21398 re-reviewed the same commit 18 times in two weeks).

Read the last page instead, via the Link header, so we inspect the bot's most recent review. This is bounded to two API calls regardless of PR size rather than paginating through every review.

Use a page size of 10 so the same mechanism doubles as a freshness trigger: once roughly 10 reviews/comments land after the bot's last review, that review drops off the last page and the PR is queued for another look even when its head has not changed.

Fixes: 2d30538852ff ("CI: add LLM-driven PR review workflows")
Assisted-by: Claude:claude-opus-4-8