### PR TITLE
CI: multi-arch-test-build: add default packages for LuCI feed

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -91,6 +91,8 @@ jobs:
             PACKAGES="${PACKAGES:-bird2 cjdns olsrd}"
           elif [ "$REPOSITORY_NAME" = "telephony" ]; then
             PACKAGES="${PACKAGES:-asterisk siproxd freeswitch}"
+          elif [ "$REPOSITORY_NAME" = "luci" ]; then
+            PACKAGES="${PACKAGES:-luci-app-commands}"
           else
             PACKAGES="${PACKAGES:-vim attendedsysupgrade-common bmon}"
           fi


### PR DESCRIPTION
Default packages for routing and telephony feeds are already present, but the LuCI feed was missing. Add it as well.

cc: @systemcrash 