### PR TITLE
ci: multi-arch-test-build: split matrix build into two stages

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -20,25 +20,57 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: Test ${{ matrix.arch }}
-    runs-on: ubuntu-latest
+  build_custom:
+    if: ${{ inputs.matrix != '' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.matrix) }}
+    uses: ./.github/workflows/reusable_test_build_single.yml
+    with:
+      arch: ${{ matrix.arch }}
+      target: ${{ matrix.target }}
+      runtime_test: ${{ matrix.runtime_test }}
+      enable_generic_tests: ${{ inputs.enable_generic_tests }}
+      force_generic_tests: ${{ inputs.force_generic_tests }}
+
+  build_early:
+    if: ${{ inputs.matrix == '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64_generic
+            target: armsr-armv8
+            runtime_test: true
+          - arch: arm_cortex-a9_vfpv3-d16
+            target: mvebu-cortexa9
+            runtime_test: false
+          - arch: powerpc_8548
+            target: mpc85xx-p1010
+            runtime_test: false
+    uses: ./.github/workflows/reusable_test_build_single.yml
+    with:
+      arch: ${{ matrix.arch }}
+      target: ${{ matrix.target }}
+      runtime_test: ${{ matrix.runtime_test }}
+      enable_generic_tests: ${{ inputs.enable_generic_tests }}
+      force_generic_tests: ${{ inputs.force_generic_tests }}
+
+  build_remaining:
+    if: ${{ inputs.matrix == '' }}
+    needs: build_early
     strategy:
       fail-fast: false
       matrix: >-
         ${{
-          inputs.matrix != '' && fromJSON(inputs.matrix) ||
           fromJSON(
             format(
               '{{"include": [
-                {{"arch": "aarch64_generic", "target": "armsr-armv8", "runtime_test": true}},
                 {{"arch": "arm_cortex-a15_neon-vfpv4", "target": "armsr-armv7", "runtime_test": true}},
-                {{"arch": "arm_cortex-a9_vfpv3-d16", "target": "mvebu-cortexa9", "runtime_test": false}},
                 {{"arch": "i386_pentium-mmx", "target": "x86-geode", "runtime_test": true}},
                 {{"arch": "mips_24kc", "target": "ath79-generic", "runtime_test": true}},
                 {{"arch": "mipsel_24kc", "target": "mt7621", "runtime_test": false}},
                 {{"arch": "powerpc_464fp", "target": "apm821xx-nand", "runtime_test": false}},
-                {{"arch": "powerpc_8548", "target": "mpc85xx-p1010", "runtime_test": false}},
                 {{"arch": "{0}", "target": "sifiveu-generic", "runtime_test": false}},
                 {{"arch": "x86_64", "target": "x86-64", "runtime_test": true}}
               ]}}',
@@ -46,196 +78,10 @@ jobs:
             )
           )
         }}
-
-    steps:
-      - name: Remove unused Android SDK, .NET, Swift, GHC
-        run: |
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/share/swift
-
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Determine branch name
-        run: |
-          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
-          case "$BRANCH" in
-            main|master|openwrt-[0-9]*\.[0-9]*)
-              ;;
-            *)
-              BRANCH="master"
-              ;;
-          esac
-          echo "Building for $BRANCH"
-          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
-
-      - name: Determine changed packages
-        run: |
-          # only detect packages with changes
-          PKG_ROOTS=$(find . -name Makefile | \
-            grep -v ".*/src/Makefile" | \
-            sed -e 's@./\(.*\)/Makefile@\1/@')
-          CHANGES=$(git diff --diff-filter=d --name-only origin/$BRANCH...)
-
-          for ROOT in $PKG_ROOTS; do
-            for CHANGE in $CHANGES; do
-              if [[ "$CHANGE" == "$ROOT"* ]]; then
-                PACKAGES+=$(echo "$ROOT" | sed -e 's@\(.*/\)*\(.*\)/@\2 @')
-                break
-              fi
-            done
-          done
-
-          # fallback to test packages if nothing explicitly changes this is
-          # should run if other mechanics in packages.git changed
-          REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}
-          if [ "$REPOSITORY_NAME" = "routing" ]; then
-            PACKAGES="${PACKAGES:-bird2 cjdns olsrd}"
-          elif [ "$REPOSITORY_NAME" = "telephony" ]; then
-            PACKAGES="${PACKAGES:-asterisk siproxd freeswitch}"
-          else
-            PACKAGES="${PACKAGES:-vim attendedsysupgrade-common bmon}"
-          fi
-
-          echo "Building $PACKAGES"
-          echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
-
-      - name: Build
-        uses: openwrt/gh-action-sdk@v11
-        env:
-          ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
-          FEEDNAME: packages_ci
-          INDEX: 1
-          V: s
-
-      - name: Move created packages to project dir
-        if: always()
-        run: cp -v bin/packages/${{ matrix.arch }}/packages_ci/* . || true
-
-      - name: Collect metadata
-        if: always()
-        run: |
-          MERGE_ID=$(git rev-parse --short HEAD)
-          echo "MERGE_ID=$MERGE_ID" >> $GITHUB_ENV
-          echo "BASE_ID=$(git rev-parse --short HEAD^1)" >> $GITHUB_ENV
-          echo "HEAD_ID=$(git rev-parse --short HEAD^2)" >> $GITHUB_ENV
-          PRNUMBER=${GITHUB_REF_NAME%/merge}
-          echo "PRNUMBER=$PRNUMBER" >> $GITHUB_ENV
-          echo "ARCHIVE_NAME=${{matrix.arch}}-PR$PRNUMBER-$MERGE_ID" >> $GITHUB_ENV
-
-      - name: Generate metadata
-        if: always()
-        run: |
-          cat << _EOF_ > PKG-INFO
-          Metadata-Version: 2.1
-          Name: ${{env.ARCHIVE_NAME}}
-          Version: $BRANCH
-          Author: $GITHUB_ACTOR
-          Home-page: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/$PRNUMBER
-          Download-URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-          Summary: $PACKAGES
-          Platform: ${{ matrix.arch }}
-
-          Packages for OpenWrt $BRANCH running on ${{matrix.arch}}, built from PR $PRNUMBER
-          at commit $HEAD_ID, against $BRANCH at commit $BASE_ID, with merge SHA $MERGE_ID.
-
-          Modified packages:
-          _EOF_
-          for p in $PACKAGES
-          do
-            echo "  "$p >> PKG-INFO
-          done
-          echo >> PKG-INFO
-          echo Full file listing: >> PKG-INFO
-          ls -al *.ipk >> PKG-INFO || true
-          ls -al *.apk >> PKG-INFO || true
-          cat PKG-INFO
-
-      - name: Store packages
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{env.ARCHIVE_NAME}}-packages
-          path: |
-            Packages
-            Packages.*
-            *.ipk
-            packages.adb
-            *.apk
-            PKG-INFO
-
-      - name: Store logs
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{env.ARCHIVE_NAME}}-logs
-          path: |
-            logs/
-            PKG-INFO
-
-      - name: Remove logs
-        if: always()
-        run: sudo rm -rf logs/ || true
-
-      - name: Check if any packages were built
-        run: |
-          if [ -n "$(find . -maxdepth 1 -type f -name '*.apk' -print -quit)" ]; then
-            echo "Found *.apk files"
-            HAVE_PKGS=true
-            PKG_MANAGER=apk
-          elif [ -n "$(find . -maxdepth 1 -type f -name '*.ipk' -print -quit)" ]; then
-            echo "Found *.ipk files"
-            HAVE_PKGS=true
-            PKG_MANAGER=opkg
-          else
-            echo "No *.apk or *.ipk files found"
-            HAVE_PKGS=false
-          fi
-          echo "HAVE_PKGS=$HAVE_PKGS" >> $GITHUB_ENV
-          echo "PKG_MANAGER=$PKG_MANAGER" >> $GITHUB_ENV
-
-      - name: Register QEMU
-        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_PKGS) }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static binfmt-support
-          sudo update-binfmts --import
-
-      - name: Checkout test scripts
-        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_PKGS) }}
-        uses: actions/checkout@v6
-        with:
-          repository: openwrt/actions-shared-workflows
-          path: workflow_context
-          sparse-checkout: |
-            .github/scripts/ci_helpers.sh
-            .github/dockerfiles/Dockerfile.feeds
-            .github/scripts/test_entrypoint.sh
-          sparse-checkout-cone-mode: false
-
-      - name: Build Docker container
-        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_PKGS) }}
-        run: |
-          docker build \
-            --build-arg ARCH \
-            --file workflow_context/.github/dockerfiles/Dockerfile.feeds \
-            --platform linux/${{ matrix.arch }} \
-            --tag test-container \
-            workflow_context/.github
-        env:
-          ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
-
-      - name: Test via Docker container
-        if: ${{ matrix.runtime_test && fromJSON(env.HAVE_PKGS) }}
-        run: |
-          docker run \
-            -e ENABLE_GENERIC_TESTS=${{ inputs.enable_generic_tests }} \
-            -e FORCE_GENERIC_TESTS=${{ inputs.force_generic_tests }} \
-            -e PKG_MANAGER=${{ env.PKG_MANAGER }} \
-            --platform linux/${{ matrix.arch }} \
-            --rm \
-            --volume $GITHUB_WORKSPACE:/ci \
-            test-container
+    uses: ./.github/workflows/reusable_test_build_single.yml
+    with:
+      arch: ${{ matrix.arch }}
+      target: ${{ matrix.target }}
+      runtime_test: ${{ matrix.runtime_test }}
+      enable_generic_tests: ${{ inputs.enable_generic_tests }}
+      force_generic_tests: ${{ inputs.force_generic_tests }}

--- a/.github/workflows/reusable_test_build_single.yml
+++ b/.github/workflows/reusable_test_build_single.yml
@@ -1,0 +1,217 @@
+name: Single Arch Test Build
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
+      runtime_test:
+        required: true
+        type: boolean
+      enable_generic_tests:
+        required: true
+        type: boolean
+      force_generic_tests:
+        required: true
+        type: boolean
+
+jobs:
+  build:
+    name: Test ${{ inputs.arch }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove unused Android SDK, .NET, Swift, GHC
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine branch name
+        run: |
+          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+          case "$BRANCH" in
+            main|master|openwrt-[0-9]*\.[0-9]*)
+              ;;
+            *)
+              BRANCH="master"
+              ;;
+          esac
+          echo "Building for $BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Determine changed packages
+        run: |
+          # only detect packages with changes
+          PKG_ROOTS=$(find . -name Makefile | \
+            grep -v ".*/src/Makefile" | \
+            sed -e 's@./\(.*\)/Makefile@\1/@')
+          CHANGES=$(git diff --diff-filter=d --name-only origin/$BRANCH...)
+
+          for ROOT in $PKG_ROOTS; do
+            for CHANGE in $CHANGES; do
+              if [[ "$CHANGE" == "$ROOT"* ]]; then
+                PACKAGES+=$(echo "$ROOT" | sed -e 's@\(.*/\)*\(.*\)/@\2 @')
+                break
+              fi
+            done
+          done
+
+          # fallback to test packages if nothing explicitly changes this is
+          # should run if other mechanics in packages.git changed
+          REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}
+          if [ "$REPOSITORY_NAME" = "routing" ]; then
+            PACKAGES="${PACKAGES:-bird2 cjdns olsrd}"
+          elif [ "$REPOSITORY_NAME" = "telephony" ]; then
+            PACKAGES="${PACKAGES:-asterisk siproxd freeswitch}"
+          else
+            PACKAGES="${PACKAGES:-vim attendedsysupgrade-common bmon}"
+          fi
+
+          echo "Building $PACKAGES"
+          echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
+
+      - name: Build
+        uses: openwrt/gh-action-sdk@v11
+        env:
+          ARCH: ${{ inputs.arch }}-${{ env.BRANCH }}
+          FEEDNAME: packages_ci
+          INDEX: 1
+          V: s
+
+      - name: Move created packages to project dir
+        if: always()
+        run: cp -v bin/packages/${{ inputs.arch }}/packages_ci/* . || true
+
+      - name: Collect metadata
+        if: always()
+        run: |
+          MERGE_ID=$(git rev-parse --short HEAD)
+          echo "MERGE_ID=$MERGE_ID" >> $GITHUB_ENV
+          echo "BASE_ID=$(git rev-parse --short HEAD^1)" >> $GITHUB_ENV
+          echo "HEAD_ID=$(git rev-parse --short HEAD^2)" >> $GITHUB_ENV
+          PRNUMBER=${GITHUB_REF_NAME%/merge}
+          echo "PRNUMBER=$PRNUMBER" >> $GITHUB_ENV
+          echo "ARCHIVE_NAME=${{inputs.arch}}-PR$PRNUMBER-$MERGE_ID" >> $GITHUB_ENV
+
+      - name: Generate metadata
+        if: always()
+        run: |
+          cat << _EOF_ > PKG-INFO
+          Metadata-Version: 2.1
+          Name: ${{env.ARCHIVE_NAME}}
+          Version: $BRANCH
+          Author: $GITHUB_ACTOR
+          Home-page: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/$PRNUMBER
+          Download-URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          Summary: $PACKAGES
+          Platform: ${{ inputs.arch }}
+
+          Packages for OpenWrt $BRANCH running on ${{inputs.arch}}, built from PR $PRNUMBER
+          at commit $HEAD_ID, against $BRANCH at commit $BASE_ID, with merge SHA $MERGE_ID.
+
+          Modified packages:
+          _EOF_
+          for p in $PACKAGES
+          do
+            echo "  "$p >> PKG-INFO
+          done
+          echo >> PKG-INFO
+          echo Full file listing: >> PKG-INFO
+          ls -al *.ipk >> PKG-INFO || true
+          ls -al *.apk >> PKG-INFO || true
+          cat PKG-INFO
+
+      - name: Store packages
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{env.ARCHIVE_NAME}}-packages
+          path: |
+            Packages
+            Packages.*
+            *.ipk
+            packages.adb
+            *.apk
+            PKG-INFO
+
+      - name: Store logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{env.ARCHIVE_NAME}}-logs
+          path: |
+            logs/
+            PKG-INFO
+
+      - name: Remove logs
+        if: always()
+        run: sudo rm -rf logs/ || true
+
+      - name: Check if any packages were built
+        run: |
+          if [ -n "$(find . -maxdepth 1 -type f -name '*.apk' -print -quit)" ]; then
+            echo "Found *.apk files"
+            HAVE_PKGS=true
+            PKG_MANAGER=apk
+          elif [ -n "$(find . -maxdepth 1 -type f -name '*.ipk' -print -quit)" ]; then
+            echo "Found *.ipk files"
+            HAVE_PKGS=true
+            PKG_MANAGER=opkg
+          else
+            echo "No *.apk or *.ipk files found"
+            HAVE_PKGS=false
+          fi
+          echo "HAVE_PKGS=$HAVE_PKGS" >> $GITHUB_ENV
+          echo "PKG_MANAGER=$PKG_MANAGER" >> $GITHUB_ENV
+
+      - name: Register QEMU
+        if: ${{ inputs.runtime_test && fromJSON(env.HAVE_PKGS) }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
+          sudo update-binfmts --import
+
+      - name: Checkout test scripts
+        if: ${{ inputs.runtime_test && fromJSON(env.HAVE_PKGS) }}
+        uses: actions/checkout@v6
+        with:
+          repository: openwrt/actions-shared-workflows
+          path: workflow_context
+          sparse-checkout: |
+            .github/scripts/ci_helpers.sh
+            .github/dockerfiles/Dockerfile.feeds
+            .github/scripts/test_entrypoint.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Build Docker container
+        if: ${{ inputs.runtime_test && fromJSON(env.HAVE_PKGS) }}
+        run: |
+          docker build \
+            --build-arg ARCH \
+            --file workflow_context/.github/dockerfiles/Dockerfile.feeds \
+            --platform linux/${{ inputs.arch }} \
+            --tag test-container \
+            workflow_context/.github
+        env:
+          ARCH: ${{ inputs.arch }}-${{ env.BRANCH }}
+
+      - name: Test via Docker container
+        if: ${{ inputs.runtime_test && fromJSON(env.HAVE_PKGS) }}
+        run: |
+          docker run \
+            -e ENABLE_GENERIC_TESTS=${{ inputs.enable_generic_tests }} \
+            -e FORCE_GENERIC_TESTS=${{ inputs.force_generic_tests }} \
+            -e PKG_MANAGER=${{ env.PKG_MANAGER }} \
+            --platform linux/${{ inputs.arch }} \
+            --rm \
+            --volume $GITHUB_WORKSPACE:/ci \
+            test-container


### PR DESCRIPTION
This tries to implement the idea from @champtar and @hauke in this pull request https://github.com/openwrt/packages/pull/29410#issuecomment-4416627030. It first runs on 3 architectures, and if they succeed, it proceeds with the rest. This selection covers aarch64 (where fPIC was most affected in the past), armv7 (as a 32-bit ARM representative), and powerpc (where Go packages are not supported).

The main benefit is that instead of triggering the whole heavy machinery for all packages at once, we initially limit it to a few architectures. If those pass, the rest are triggered. For users on architectures other than the first three, the total build time might increase by dozens of minutes or even hours, but it will significantly save runner capacity and time if the build fails early.

It will certainly be interesting to see how this impacts the main OpenWrt repository. Note that I am still keeping a custom matrix for certain repositories such as LuCI, where packages are compiled only for x86_64.

For now, I want to test this first to verify it works as expected. This PR is currently meant more as a discussion starter on whether this approach makes sense.

I also recall that @hnyman was looking for or requesting something similar.