### PR TITLE
ci: test_entrypoint: drop the kmods feed before installing packages

### DIFF
--- a/.github/scripts/test_entrypoint.sh
+++ b/.github/scripts/test_entrypoint.sh
@@ -270,10 +270,19 @@ if is_opkg; then
 	# it's possible to do it for the local feed only, which has signing removed.
 	# This fixes running CI tests.
 	sed -i '/check_signature/d' /etc/opkg.conf
+	# The kmods feed only exists for the exact kernel the rootfs image was
+	# built with. Once the branch moves to a newer kernel, the old kmods
+	# directory is removed from the download server and the update fails
+	# with a 404, taking down every runtime test. The tests install the
+	# built packages from the local feed and do not need the kmods feed,
+	# so drop it instead of failing on it.
+	sed -i '/\/kmods\//d' /etc/opkg/distfeeds.conf
 	opkg update
 	opkg install $TEST_PACKAGES
 elif is_apk; then
 	echo "/ci/packages.adb" >> /etc/apk/repositories.d/distfeeds.list
+	# Drop the kmods feed for the same reason as in the opkg case above.
+	sed -i '/\/kmods\//d' /etc/apk/repositories.d/distfeeds.list
 	apk update
 	apk add $TEST_PACKAGES
 fi


### PR DESCRIPTION
The runtime-test containers are built from the `openwrt/rootfs:<arch>-<branch>` images, which carry the kmods feed URL for the exact kernel they were built with. When the branch moves to a newer kernel, the old kmods directory is removed from the download server and `opkg update` inside the container fails with a 404, so every runtime test fails even though the tested package built fine. This is currently the case for all `-openwrt-24.10` images (see e.g. openwrt/packages#30260, where the package compiles on all architectures but the runtime tests fail with a 404 on the kmods feed).

The tests install the built packages from the local `packages_ci` feed and do not need the kmods feed, so drop it from the feed configuration before updating. The apk-based branches generate the same kmods entry in `distfeeds.list` (`include/feeds.mk` in openwrt.git), so both package managers get the same treatment.

This complements openwrt/docker#208, which keeps the images fresh — this change keeps the tests working when they are not.
